### PR TITLE
Fix integration tests

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -66,32 +66,32 @@ class DevelopmentConfig:
     LOG_LEVEL = env("LOG_LEVEL", default="INFO")
     STATIC_ROOT = "app/static"
 
-    ACCOUNT_SERVICE_URL = env.str("ACCOUNT_SERVICE_URL", default="http://0.0.0.0:9092")
-    EQ_URL = env.str("EQ_URL", default="http://0.0.0.0:5000/session?token=")
+    ACCOUNT_SERVICE_URL = env.str("ACCOUNT_SERVICE_URL", default="http://localhost:9092")
+    EQ_URL = env.str("EQ_URL", default="http://localhost:5000/session?token=")
     JSON_SECRET_KEYS = env.str("JSON_SECRET_KEYS", default=None) or open("./tests/test_data/test_keys.json").read()
 
-    COLLECTION_EXERCISE_URL = env.str("COLLECTION_EXERCISE_URL", default="http://0.0.0.0:8145")
+    COLLECTION_EXERCISE_URL = env.str("COLLECTION_EXERCISE_URL", default="http://localhost:8145")
     COLLECTION_EXERCISE_AUTH = (
         env.str("COLLECTION_EXERCISE_USERNAME", default="admin"),
         env.str("COLLECTION_EXERCISE_PASSWORD", default="secret")
     )
 
-    COLLECTION_INSTRUMENT_URL = env.str("COLLECTION_INSTRUMENT_URL", default="http://0.0.0.0:8002")
+    COLLECTION_INSTRUMENT_URL = env.str("COLLECTION_INSTRUMENT_URL", default="http://localhost:8002")
     COLLECTION_INSTRUMENT_AUTH = (
         env.str("COLLECTION_INSTRUMENT_USERNAME", default="admin"),
         env.str("COLLECTION_INSTRUMENT_PASSWORD", default="secret")
     )
 
-    CASE_URL = env.str("CASE_URL", default="http://0.0.0.0:8171")
+    CASE_URL = env.str("CASE_URL", default="http://localhost:8171")
     CASE_AUTH = (env.str("CASE_USERNAME", default="admin"), env.str("CASE_PASSWORD", default="secret"))
 
-    IAC_URL = env.str("IAC_URL", default="http://0.0.0.0:8121")
+    IAC_URL = env.str("IAC_URL", default="http://localhost:8121")
     IAC_AUTH = (env.str("IAC_USERNAME", default="admin"), env.str("IAC_PASSWORD", default="secret"))
 
-    SAMPLE_URL = env("SAMPLE_URL", default="http://0.0.0.0:8125")
+    SAMPLE_URL = env("SAMPLE_URL", default="http://localhost:8125")
     SAMPLE_AUTH = (env("SAMPLE_USERNAME", default="admin"), env("SAMPLE_PASSWORD", default="secret"))
 
-    SURVEY_URL = env("SURVEY_URL", default="http://0.0.0.0:8080")
+    SURVEY_URL = env("SURVEY_URL", default="http://localhost:8080")
     SURVEY_AUTH = (env("SURVEY_USERNAME", default="admin"), env("SURVEY_PASSWORD", default="secret"))
 
     SECRET_KEY = env.str("SECRET_KEY", default=None) or generate_new_key()
@@ -103,26 +103,26 @@ class TestingConfig:
     LOG_LEVEL = "INFO"
     STATIC_ROOT = "app/static"
 
-    ACCOUNT_SERVICE_URL = "http://0.0.0.0:9092"
-    EQ_URL = "http://0.0.0.0:5000/session?token="
+    ACCOUNT_SERVICE_URL = "http://localhost:9092"
+    EQ_URL = "http://localhost:5000/session?token="
     JSON_SECRET_KEYS = open("./tests/test_data/test_keys.json").read()
 
-    COLLECTION_EXERCISE_URL = "http://0.0.0.0:8145"
+    COLLECTION_EXERCISE_URL = "http://localhost:8145"
     COLLECTION_EXERCISE_AUTH = ("admin", "secret")
 
-    COLLECTION_INSTRUMENT_URL = "http://0.0.0.0:8002"
+    COLLECTION_INSTRUMENT_URL = "http://localhost:8002"
     COLLECTION_INSTRUMENT_AUTH = ("admin", "secret")
 
-    CASE_URL = "http://0.0.0.0:8171"
+    CASE_URL = "http://localhost:8171"
     CASE_AUTH = ("admin", "secret")
 
-    IAC_URL = "http://0.0.0.0:8121"
+    IAC_URL = "http://localhost:8121"
     IAC_AUTH = ("admin", "secret")
 
-    SAMPLE_URL = "http://0.0.0.0:8125"
+    SAMPLE_URL = "http://localhost:8125"
     SAMPLE_AUTH = ("admin", "secret")
 
-    SURVEY_URL = "http://0.0.0.0:8080"
+    SURVEY_URL = "http://localhost:8080"
     SURVEY_AUTH = ("admin", "secret")
 
     SECRET_KEY = generate_new_key()

--- a/scripts/setup_data.sh
+++ b/scripts/setup_data.sh
@@ -7,7 +7,7 @@ if [ -d tmp_rm_tools ]; then
     echo "tmp_rm_tools exists - pulling";
     cd tmp_rm_tools; git pull; cd -;
 else
-    git clone -b social-test-setup --depth 1 --single-branch ${rm_tools_repo_url} tmp_rm_tools;
+    git clone --depth 1 ${rm_tools_repo_url} tmp_rm_tools;
 fi;
 cp tests/test_data/setup.env tmp_rm_tools/social-test-setup/.env
 cp tests/test_data/sample/social-survey-sample.csv tmp_rm_tools/social-test-setup/data/

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import requests
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
@@ -16,7 +17,6 @@ class TestRespondentHome(AioHTTPTestCase):
     """
     Assumes services are running on the default ports with social data pre-loaded with `make setup`.
     """
-
     async def get_application(self):
         return create_app('TestingConfig')
 
@@ -56,11 +56,19 @@ class TestRespondentHome(AioHTTPTestCase):
         logger.debug('Successfully retrieved sample unit', sample_unit_id=sample_unit_id)
         return response.json()['sampleAttributes']['attributes']['Prem1']
 
+    @staticmethod
+    def poll_for_iac(sample_unit_id):
+        while True:
+            time.sleep(5)
+            iac = TestRespondentHome.get_iac_by_sample_unit_id(sample_unit_id)
+            if iac is not None:
+                return iac
+
     @unittest_run_loop
     async def test_can_access_respondent_home_homepage(self):
         sample_summary_id = self.get_first_sample_summary_id()
         sample_unit_id = self.get_first_sample_unit_id_by_summary(sample_summary_id)
-        iac = self.get_iac_by_sample_unit_id(sample_unit_id)
+        iac = self.poll_for_iac(sample_unit_id)
         iac1, iac2, iac3 = iac[:4], iac[4:8], iac[8:]
         form_data = {
             'iac1': iac1, 'iac2': iac2, 'iac3': iac3, 'action[save_continue]': '',

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -37,7 +37,7 @@ class TestRespondentHome(unittest.TestCase):
         response = requests.get(url, auth=Config.BASIC_AUTH)
         response.raise_for_status()
         logger.debug('Successfully retrieved case', sample_unit_id=sample_unit_id)
-        return response.json()['iac']
+        return response.json()[0]['iac']
 
     @staticmethod
     def get_address_by_sample_unit_id(sample_unit_id):
@@ -67,6 +67,6 @@ class TestRespondentHome(unittest.TestCase):
         iac = self.get_iac_by_sample_unit_id(sample_unit_id)
         response = self.post_to_rh(iac)
 
-        assert response.status == 200
+        assert response.status_code == 200
         assert Config.EQ_SURVEY_RUNNER_URL in response.url
-        assert self.get_address_by_sample_unit_id(sample_unit_id) in response.content
+        assert self.get_address_by_sample_unit_id(sample_unit_id).encode() in response.content


### PR DESCRIPTION
# Motivation and Context
Integration test would fail as [the new case endpoint](https://github.com/ONSdigital/rm-case-service/pull/55) (`/cases?sampleUnitId=[uuid]`) returns a list of cases.

Other fixes for using master of setup tools and config (localhost: aligns with other services defaults) and string comparison and waiting for iac.

# How to test?
`make test` for...  🍰 !

