### PR TITLE
Force string repr of URLs in logs

### DIFF
--- a/app/case.py
+++ b/app/case.py
@@ -13,10 +13,10 @@ async def get_case(case_id: str, app: Application):
         try:
             response.raise_for_status()
         except ClientError as ex:
-            logger.error("Error retrieving case", case_id=case_id, url=response.url, status_code=response.status)
+            logger.error("Error retrieving case", case_id=case_id, url=str(response.url), status_code=response.status)
             raise ex
         else:
-            logger.debug("Successfully retrieved case", case_id=case_id, url=response.url)
+            logger.debug("Successfully retrieved case", case_id=case_id, url=str(response.url))
         return await response.json()
 
 
@@ -29,8 +29,8 @@ async def post_case_event(case_id: str, category: str, description: str, app: Ap
         try:
             response.raise_for_status()
         except ClientError as ex:
-            logger.error("Error posting case event", case_id=case_id, url=response.url, status_code=response.status)
+            logger.error("Error posting case event", case_id=case_id, url=str(response.url), status_code=response.status)
             raise ex
         else:
-            logger.debug("Successfully posted case event", case_id=case_id, url=response.url)
+            logger.debug("Successfully posted case event", case_id=case_id, url=str(response.url))
         return await response.json()

--- a/app/eq.py
+++ b/app/eq.py
@@ -21,10 +21,10 @@ def handle_response(response):
     try:
         response.raise_for_status()
     except ClientError as ex:
-        logger.error("Error in response", url=response.url, status_code=response.status)
+        logger.error("Error in response", url=str(response.url), status_code=response.status)
         raise ex
     else:
-        logger.debug("Successfully connected to service", url=response.url)
+        logger.debug("Successfully connected to service", url=str(response.url))
 
 
 def find_event_date_by_tag(search_param: str, collex_events: dict, collex_id: str, mandatory: bool):


### PR DESCRIPTION
aiohttp responses from client requests have URL attributes that are URL type objects and not strings.

This forces the string representation of a response's URL in the logs.