### PR TITLE
Fixed the broken links in the footer

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -59,10 +59,10 @@
                 <div class="grid__col col-12@m">
                     <ul class="list list--bare">
                         <li>
-                            <a href="/contact-us" class="footer__link footer__link--inline" target="_blank">Contact us</a>
+                            <a href="https://www.ons.gov.uk/aboutus/contactus" class="footer__link footer__link--inline" target="_blank">Contact us</a>
                         </li>
                         <li>
-                            <a href="/cookies-privacy" class="footer__link footer__link--inline" target="_blank">Cookies and privacy</a>
+                            <a href="https://www.ons.gov.uk/help/cookiesandprivacy" class="footer__link footer__link--inline" target="_blank">Cookies and privacy</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
"Contact us" and "Cookies and privacy" links now pointing to equivalent pages on the ONS website.

Fixes: #27 