### PR TITLE
Remove reference to secure message in log setup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 120
+max-line-length = 160

--- a/app/app.py
+++ b/app/app.py
@@ -56,6 +56,7 @@ def create_app(config_name=None) -> web.Application:
     logger_initial_config(service_name="respondent-home", log_level=app["LOG_LEVEL"])
 
     logger.info("Logging configured", log_level=app['LOG_LEVEL'])
+
     # Set up routes
     routes.setup(app)
 

--- a/app/app_logging.py
+++ b/app/app_logging.py
@@ -18,7 +18,7 @@ def logger_initial_config(
     if not logger_format:
         logger_format = "%(message)s"
     if not service_name:
-        service_name = os.getenv("NAME", "ras-secure-message")
+        service_name = os.getenv("NAME", "respondent-home")
     try:
         indent = int(os.getenv("JSON_INDENT_LOGGING"))
     except TypeError:


### PR DESCRIPTION
## What has changed?
- Removed reference to secure message in initial logging setup 
- Increased flake8 line limit to 160
- Added missing line padding in app.py 