### PR TITLE
Require country code in eQ payload

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -150,8 +150,12 @@ class EqPayloadConstructor(object):
         except KeyError:
             raise InvalidEqPayLoad(f"Could not retrieve ru_name (address) for case {self._case_id}")
 
+        try:
+            self._country_code = self._sample_attributes["CountryCode"]
+        except KeyError:
+            raise InvalidEqPayLoad(f"Could not retrieve country_code for case {self._case_id}")
+
         # TODO: Remove hardcoded language variables for payload when they become available in RAS/RM
-        self._region_code = 'GB-ENG'
         self._language_code = 'en'  # sample attributes do not currently have language details
 
         self._payload = {
@@ -169,7 +173,7 @@ class EqPayloadConstructor(object):
             "case_id": self._case_id,  # not required by eQ but useful for downstream
             "case_ref": self._case_ref,  # not required by eQ but useful for downstream
             "account_service_url": self._account_service_url,  # required for save/continue
-            "region_code": self._region_code,
+            "country_code": self._country_code,
             "language_code": self._language_code,  # currently only 'en' or 'cy'
             "display_address": self.build_display_address(self._sample_attributes),  # built from the Prem attributes
         }

--- a/tests/demo/demo.py
+++ b/tests/demo/demo.py
@@ -10,7 +10,6 @@ from app.app import create_app
 
 class DemoRunner:
 
-    region_code = 'GB-ENG'
     language_code = 'en'
 
     start_date = '2018-04-10'
@@ -68,7 +67,7 @@ class DemoRunner:
             "case_id": self.case_id,
             "case_ref": self.case_ref,
             "account_service_url": self.app['ACCOUNT_SERVICE_URL'],
-            "region_code": self.region_code,
+            "country_code": self.sample_attributes_json['attributes']['CountryCode'],
             "language_code": self.language_code,
             "return_by": self.return_by,
             "ref_p_end_date": self.end_date,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -134,7 +134,6 @@ def skip_encrypt(func, *args, **kwargs):
 
 class RHTestCase(AioHTTPTestCase):
 
-    region_code = 'GB-ENG'
     language_code = 'en'
 
     start_date = '2018-04-10'
@@ -228,7 +227,6 @@ class RHTestCase(AioHTTPTestCase):
             "case_id": self.case_id,
             "case_ref": self.case_ref,
             "account_service_url": self.app['ACCOUNT_SERVICE_URL'],
-            "region_code": self.region_code,
             "language_code": self.language_code,
             "return_by": self.return_by,
             "ref_p_end_date": self.end_date,

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -112,8 +112,9 @@ class TestEq(RHTestCase):
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
-            with self.assertRaises(InvalidEqPayLoad):
+            with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"Collection instrument {self.collection_instrument_id} type is not EQ", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_ci_type(self):
@@ -125,8 +126,9 @@ class TestEq(RHTestCase):
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
-            with self.assertRaises(InvalidEqPayLoad):
+            with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"No Collection Instrument type for {self.collection_instrument_id}", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_classifiers(self):
@@ -138,8 +140,9 @@ class TestEq(RHTestCase):
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
-            with self.assertRaises(InvalidEqPayLoad):
+            with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"Could not retrieve classifiers for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_eq_id(self):
@@ -151,8 +154,9 @@ class TestEq(RHTestCase):
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
-            with self.assertRaises(InvalidEqPayLoad):
+            with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"Could not retrieve eq_id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_form_type(self):
@@ -164,8 +168,9 @@ class TestEq(RHTestCase):
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
-            with self.assertRaises(InvalidEqPayLoad):
+            with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"Could not retrieve form_type for eq_id {self.eq_id}", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_exerciseRef(self):
@@ -178,8 +183,9 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
-            with self.assertRaises(InvalidEqPayLoad):
+            with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"Could not retrieve period id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_exercise_id(self):
@@ -192,8 +198,9 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
-            with self.assertRaises(InvalidEqPayLoad):
+            with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"Could not retrieve ce id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_name(self):
@@ -208,8 +215,26 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
             mocked.get(self.sample_attributes_url, payload=sample_json)
 
-            with self.assertRaises(InvalidEqPayLoad):
+            with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"Could not retrieve ru_name (address) for case {self.case_id}", ex.exception.message)
+
+    @unittest_run_loop
+    async def test_build_raises_InvalidEqPayLoad_missing_country_code(self):
+        sample_json = self.sample_attributes_json.copy()
+        del sample_json['attributes']['CountryCode']
+
+        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
+
+        with aioresponses() as mocked:
+            mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
+            mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
+            mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
+            mocked.get(self.sample_attributes_url, payload=sample_json)
+
+            with self.assertRaises(InvalidEqPayLoad) as ex:
+                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+            self.assertIn(f"Could not retrieve country_code for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_attributes(self):


### PR DESCRIPTION
# Motivation and Context
A sample file has no concept of a region code and previously we were hard coding it to "GB-ENG". Following a [recent change to the schema in eQ Runner](https://github.com/ONSdigital/eq-survey-runner/pull/1705) we can drop it in favour of expecting a country code from the sample attributes instead.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Expect a country code present in the sample attributes
- Remove region code from the payload
- Update to the unit tests to fail on missing country code

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
`make test` should do it

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
- [eQ runner PR introducing the country code](https://github.com/ONSdigital/eq-survey-runner/pull/1705)
- [LMS 1 schema](https://github.com/ONSdigital/eq-survey-runner/blob/master/data/en/lms_1.json)
