### PR TITLE
Event dates are optional in LMS

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -180,6 +180,7 @@ class EqPayloadConstructor(object):
         )
 
         # Add any non null event dates that exist for this collection exercise
+        # NB: for LMS the event dates are optional
         self._payload.update(
             [(key, value) for key, value in self._collex_event_dates.items() if value is not None]
         )
@@ -239,12 +240,12 @@ class EqPayloadConstructor(object):
     def _get_collex_event_dates(self):
         return {
             "ref_p_start_date": find_event_date_by_tag(
-                "ref_period_start", self._collex_events, self._collex_id, True
+                "ref_period_start", self._collex_events, self._collex_id, False
             ),
             "ref_p_end_date": find_event_date_by_tag(
-                "ref_period_end", self._collex_events, self._collex_id, True
+                "ref_period_end", self._collex_events, self._collex_id, False
             ),
             "return_by": find_event_date_by_tag(
-                "return_by", self._collex_events, self._collex_id, True
+                "return_by", self._collex_events, self._collex_id, False
             ),
         }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The collection exercise event dates are non-mandatory for LMS to run the survey in eQ. They are, however, passed to SDX if present.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Remove the enforcement of mandatory for a CE event dates in Respondent Home UI.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the unit tests (`make unittests`) and/or launch a new UAC from a collection exercise without event dates (return by, start date, end date) set.
