### PR TITLE
Have full eQ path only in redirect line

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -161,26 +161,27 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:025a96e48164106f2082b00f42bf430cf21f09e203e42585a712e420b75cbff0",
-                "sha256:2230c186182d773064d06242e0fa604cd718bfff28aa9c5ae73d7e426e98a151",
-                "sha256:2908f709f02711dbb10561a9f154d2f7d1792385e2341e9708539cc4ecfb8667",
-                "sha256:2a5e577f5d2093e51486b4ec02b51bb5adb165b98fee99929d5af0813e90b469",
-                "sha256:2eb8297b877cb6b56216750fa7017c9f5786bec8afd6a0f1aaace02cbfb6195f",
-                "sha256:365eb804362e581c9a02e7a610b30514f07dd77b2a38aed338eb5192446bbc58",
-                "sha256:3dc94ed5a26b8553a325767358f505c0a43e0c89df078647f77a4d022ddcdc57",
-                "sha256:469a9d3d851038f1eb7d7f77bb08bb4775b41483372be450e25b293fe57bd59e",
-                "sha256:533143321d15c8743f91eec5c5f495c1b5cad9a25de8f6dab01eddd6b416903e",
-                "sha256:5474fe5ce6b517d3086e0231b6ad88f8978c551c4379f91c3d619c308490f0d7",
-                "sha256:5518337022718029e367d982642f3e3523541e098ad671672a90b82474c84882",
-                "sha256:5ff169869624e23767d70db274f13a9ea4e97c029425a1224aa5e049e84ce2af",
-                "sha256:61eb3534f8ed2415dd708b28919205d523f220e4cd5b8165844edfdd4a649b8e",
-                "sha256:7db719432648f14ea33edffc5f75330c595804eac86ca916528b35ce50a8bfd6",
-                "sha256:9d9da8bac2e31003d092f5ef6981a725c77c4e9a30638436884d61ad39f9a1ee",
-                "sha256:c26e057a2de13e97e708328d295c5ac4cd3eab4a5c42ce727dd1a53316034b8a",
-                "sha256:ca72537a7064bb80e34b6908e576ffc8e2c2cad29a7168f48d0999df089695c3",
-                "sha256:fab8ec6866e384d9827d5dc02a1383e991a6c05c54f818316c4b829e56ca2ba3"
+                "sha256:21af753934f2f6d1a10fe8f4c0a64315af209ef6adeaee63ca349797d747d687",
+                "sha256:27bb401a20a838d6d0ea380f08c6ead3ccd8c9d8a0232dc9adcc0e4994576a66",
+                "sha256:29720c4253263cff9aea64585adbbe85013ba647f6e98367efff9db2d7193ded",
+                "sha256:2a35b7570d8f247889784010aac8b384fd2e4a47b33e15c4a60b45a7c1944120",
+                "sha256:42c531a6a354407f42ee07fda5c2c0dc822cf6d52744949c182f2b295fbd4183",
+                "sha256:5eb86f03f9c4f0ac2336ac5431271072ddf7ecc76b338e26366732cfac58aa19",
+                "sha256:67f7f57eae8dede577f3f7775957f5bec93edd6bdb6ce597bb5b28e1bdf3d4fb",
+                "sha256:6ec84edcbc966ae460560a51a90046503ff0b5b66157a9efc61515c68059f6c8",
+                "sha256:7ba834564daef87557e7fcd35c3c3183a4147b0b3a57314e53317360b9b201b3",
+                "sha256:7d7f084cbe1fdb82be5a0545062b59b1ad3637bc5a48612ac2eb428ff31b31ea",
+                "sha256:82409f5150e529d699e5c33fa8fd85e965104db03bc564f5f4b6a9199e591f7c",
+                "sha256:87d092a7c2a44e5f7414ab02fb4145723ebba411425e1a99773531dd4c0e9b8d",
+                "sha256:8c56ef989342e42b9fcaba7c74b446f0cc9bed546dd00034fa7ad66fc00307ef",
+                "sha256:9449f5d4d7c516a6118fa9210c4a00f34384cb1d2028672100ee0c6cce49d7f6",
+                "sha256:bc2301170986ad82d9349a91eb8884e0e191209c45f5541b16aa7c0cfb135978",
+                "sha256:c132bab45d4bd0fff1d3fe294d92b0a6eb8404e93337b3127bdec9f21de117e6",
+                "sha256:c3d945b7b577f07a477700f618f46cbc287af3a9222cd73035c6ef527ef2c363",
+                "sha256:cee18beb4c807b5c0b178f4fa2fae03cef9d51821a358c6890f8b23465b7e5d2",
+                "sha256:d01dfc5c2b3495184f683574e03c70022674ca9a7be88589c5aba130d835ea90"
             ],
-            "version": "==1.9"
+            "version": "==2.3"
         },
         "envparse": {
             "hashes": [
@@ -211,12 +212,12 @@
         },
         "invoke": {
             "hashes": [
-                "sha256:1db6cf918e5df10efe4d61101b19763abe1510b6b2fe8c553daba25476de8044",
-                "sha256:265eead8c89805a2ac5083200842db6da7636ac63fb4fe0d1121b930770f3e2a",
-                "sha256:3e8e2c2e69493227e210a1d19ccc7c44189240385dda4c9b8eb5d98fa0f68a3e"
+                "sha256:1c2cf54c9b9af973ad9704d8ba81b225117cab612568cacbfb3fc42958cc20a9",
+                "sha256:334495ea16e73948894e9535019f87a88a44b73e7977492b12c2d1b5085f8197",
+                "sha256:54bdd3fd0245abd1185e05359fd2e4f26be0657cfe7d7bb1bed735e054fa53ab"
             ],
             "index": "pypi",
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "iso8601": {
             "hashes": [
@@ -236,10 +237,10 @@
         },
         "jwcrypto": {
             "hashes": [
-                "sha256:157be93f8f7832bcafc2f7444d5945edabdaaa1297e655d1ef65e869fb716b19",
-                "sha256:5b2565104caec6dbe612557ffbffc1489a7287d8ffed00e3a803b2bfdc5e063b"
+                "sha256:3158ea0ccb70407ec441e76d67aeb827ff85adb142291c1d184f8b8bd4dbdb93",
+                "sha256:82ea1ec2a2246d69858652796f19d3d88b01e1da14602c1dce5daf02a65b20ac"
             ],
-            "version": "==0.4.0"
+            "version": "==0.5"
         },
         "markupsafe": {
             "hashes": [
@@ -322,11 +323,11 @@
         },
         "sdc-cryptography": {
             "hashes": [
-                "sha256:c2ee420cb580349a1d2319825caf3f29c99ff29056fa9bcf54f0c86c85e021ad",
-                "sha256:e4e9ef714972608b2010e3920a0217d1fbe1deaada378bb0c87f5c8b9d01d312"
+                "sha256:11e20b816835137b125f3e8331e7cbfa30801651a775014b1abdd9fac850b227",
+                "sha256:37d7d14197014038dfa63eaaecac46c48a05e0f3fd23c1cdb1d9f6d612e6e31e"
             ],
             "index": "pypi",
-            "version": "==0.2.2"
+            "version": "==0.2.3"
         },
         "six": {
             "hashes": [
@@ -480,8 +481,11 @@
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
                 "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
@@ -504,11 +508,16 @@
                 "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
                 "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
                 "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
                 "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "index": "pypi",
             "version": "==4.5.1"
@@ -593,11 +602,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
-                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "multidict": {
             "hashes": [
@@ -644,7 +653,6 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==0.7.1"
         },
         "prompt-toolkit": {

--- a/app/app.py
+++ b/app/app.py
@@ -37,6 +37,7 @@ def create_app(config_name=None) -> web.Application:
     app_config = config.Config()
     app_config.from_object(settings)
 
+    # NB: raises ConfigurationError if an object attribute is None
     app_config.from_object(getattr(config, config_name or app_config["ENV"]))
 
     # Create basic auth for services

--- a/app/config.py
+++ b/app/config.py
@@ -71,7 +71,7 @@ class DevelopmentConfig:
     STATIC_ROOT = "app/static"
 
     ACCOUNT_SERVICE_URL = env.str("ACCOUNT_SERVICE_URL", default="http://localhost:9092")
-    EQ_URL = env.str("EQ_URL", default="http://localhost:5000/session?token=")
+    EQ_URL = env.str("EQ_URL", default="http://localhost:5000")
     JSON_SECRET_KEYS = env.str("JSON_SECRET_KEYS", default=None) or open("./tests/test_data/test_keys.json").read()
 
     COLLECTION_EXERCISE_URL = env.str("COLLECTION_EXERCISE_URL", default="http://localhost:8145")
@@ -108,7 +108,7 @@ class TestingConfig:
     STATIC_ROOT = "app/static"
 
     ACCOUNT_SERVICE_URL = "http://localhost:9092"
-    EQ_URL = "http://localhost:5000/session?token="
+    EQ_URL = "http://localhost:5000"
     JSON_SECRET_KEYS = open("./tests/test_data/test_keys.json").read()
 
     COLLECTION_EXERCISE_URL = "http://localhost:8145"

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -95,7 +95,7 @@ async def post_index(request):
     await post_case_event(case_id, 'EQ_LAUNCH', description, request.app)
 
     logger.info('Redirecting to eQ', client_ip=client_ip)
-    raise HTTPFound(request.app['EQ_URL'] + token)
+    raise HTTPFound(f"{request.app['EQ_URL']}/session?token={token}")
 
 
 def validate_case(case_json):

--- a/tests/test_data/local.env
+++ b/tests/test_data/local.env
@@ -11,7 +11,7 @@ COLLECTION_EXERCISE_USERNAME=admin
 COLLECTION_INSTRUMENT_PASSWORD=secret
 COLLECTION_INSTRUMENT_URL=http://localhost:8002
 COLLECTION_INSTRUMENT_USERNAME=admin
-EQ_URL="http://localhost:5000/session?token="
+EQ_URL="http://localhost:5000"
 HOST=0.0.0.0
 IAC_PASSWORD=secret
 IAC_URL=http://localhost:8121


### PR DESCRIPTION
NB: This will require the environment variables for EQ_URL to be updated to only include host, protocol and port. 

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It was [pointed out](https://github.com/ONSdigital/ras-deploy/pull/55#discussion_r206826554) that the full path does not change between environments. This pins the full path to eQ to the redirect URL line only.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Expect `[protocol]://[host](:[port])` only in the environment variable `EQ_URL`. Full path built at redirect time.
Took the opportunity to update insecure packages.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
`make unittests` or `make test` for the full end-to-end (with eQ runner).

# Links
https://github.com/ONSdigital/ras-deploy/pull/55