### PR TITLE
Change format of display address

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -198,16 +198,16 @@ class EqPayloadConstructor(object):
         Build `display_address` value by appending not-None (in order) values of sample attributes
 
         :param sample_attributes: dictionary of address attributes
-        :return: string of a single prem value or a combination of two
+        :return: string of a single address attribute or a combination of two
         """
         display_address = ''
-        for prem_key in ['Prem1', 'Prem2', 'Prem3', 'Prem4', 'District', 'PostTown', 'Postcode']:  # retain order of Prem values
+        for prem_key in ['Prem1', 'Prem2', 'Prem3', 'Prem4', 'District', 'PostTown', 'Postcode']:  # retain order of address attributes
             val = sample_attributes.get(prem_key)
             if val:
                 prev_display = display_address
                 display_address = f'{prev_display}, {val}' if prev_display else val
                 if prev_display:
-                    break  # break once two prems have been added
+                    break  # break once two address attributes have been added
         if not display_address:
             raise InvalidEqPayLoad("Displayable address not in sample attributes")
         return display_address

--- a/app/eq.py
+++ b/app/eq.py
@@ -195,22 +195,21 @@ class EqPayloadConstructor(object):
     @staticmethod
     def build_display_address(sample_attributes):
         """
-        Build `display_address` value by appending not-None (in order) prem values of sample attributes
+        Build `display_address` value by appending not-None (in order) values of sample attributes
 
-        :param sample_attributes: dictionary of attributes with Prem1, Prem2, Prem3, Prem4 keys present
+        :param sample_attributes: dictionary of address attributes
         :return: string of a single prem value or a combination of two
         """
         display_address = ''
-        for prem_key in ['Prem1', 'Prem2', 'Prem3', 'Prem4']:  # retain order of Prem values
-            try:
-                val = sample_attributes[prem_key]
-            except KeyError:
-                raise InvalidEqPayLoad(f"{prem_key} missing from sample attributes")
+        for prem_key in ['Prem1', 'Prem2', 'Prem3', 'Prem4', 'District', 'PostTown', 'Postcode']:  # retain order of Prem values
+            val = sample_attributes.get(prem_key)
             if val:
                 prev_display = display_address
-                display_address = f'{prev_display} {val}' if prev_display else val
+                display_address = f'{prev_display}, {val}' if prev_display else val
                 if prev_display:
                     break  # break once two prems have been added
+        if not display_address:
+            raise InvalidEqPayLoad("Displayable address not in sample attributes")
         return display_address
 
     async def _make_request(self, request: Request):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -233,7 +233,7 @@ class RHTestCase(AioHTTPTestCase):
             "return_by": self.return_by,
             "ref_p_end_date": self.end_date,
             "ref_p_start_date": self.start_date,
-            "display_address": self.sample_attributes_json['attributes']['Prem1'],
+            "display_address": f"{self.sample_attributes_json['attributes']['Prem1']}, {self.sample_attributes_json['attributes']['PostTown']}",
             "prem_1": self.sample_attributes_json['attributes']['Prem1'],
             "prem_2": self.sample_attributes_json['attributes']['Prem2'],
             "prem_3": self.sample_attributes_json['attributes']['Prem3'],

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -292,8 +292,9 @@ class TestEq(RHTestCase):
 
         attributes = {}
 
-        with self.assertRaises(InvalidEqPayLoad):
+        with self.assertRaises(InvalidEqPayLoad) as ex:
             eq.EqPayloadConstructor.build_display_address(attributes)
+            self.assertIn("Displayable address not in sample attributes", ex.exception.message)
 
     def test_build_display_address_prems(self):
         from app import eq

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -290,12 +290,10 @@ class TestEq(RHTestCase):
     def test_build_display_address_raises(self):
         from app import eq
 
-        attributes = self.sample_attributes_json['attributes'].copy()
-        del attributes['Prem2']
+        attributes = {}
 
-        with self.assertRaises(InvalidEqPayLoad) as ex:
+        with self.assertRaises(InvalidEqPayLoad):
             eq.EqPayloadConstructor.build_display_address(attributes)
-        self.assertIn("Prem2 missing from sample attributes", ex.exception.message)
 
     def test_build_display_address_prems(self):
         from app import eq
@@ -330,55 +328,82 @@ class TestEq(RHTestCase):
                 "Prem2": "On The Second Hill",
                 "Prem3": "",
                 "Prem4": "",
-            }, "A House On The Second Hill"),
+            }, "A House, On The Second Hill"),
             ({
                 "Prem1": "A House",
                 "Prem2": "",
                 "Prem3": "On The Third Hill",
                 "Prem4": "",
-            }, "A House On The Third Hill"),
+            }, "A House, On The Third Hill"),
             ({
                 "Prem1": "A House",
                 "Prem2": "",
                 "Prem3": "",
                 "Prem4": "On The Fourth Hill",
-            }, "A House On The Fourth Hill"),
+            }, "A House, On The Fourth Hill"),
             ({
                  "Prem1": "",
                  "Prem2": "A Second House",
                  "Prem3": "On The Third Hill",
                  "Prem4": "",
-            }, "A Second House On The Third Hill"),
+            }, "A Second House, On The Third Hill"),
             ({
                  "Prem1": "",
                  "Prem2": "A Second House",
                  "Prem3": "",
                  "Prem4": "On The Fourth Hill",
-            }, "A Second House On The Fourth Hill"),
+            }, "A Second House, On The Fourth Hill"),
             ({
                  "Prem1": "",
                  "Prem2": "",
                  "Prem3": "A Third House",
                  "Prem4": "On The Fourth Hill",
-            }, "A Third House On The Fourth Hill"),
+            }, "A Third House, On The Fourth Hill"),
             ({
                  "Prem1": "A House",
                  "Prem2": "On The Second Hill",
                  "Prem3": "Down The Third Lane",
                  "Prem4": "",
-            }, "A House On The Second Hill"),
+            }, "A House, On The Second Hill"),
             ({
                  "Prem1": "A House",
                  "Prem4": "",
                  "Prem2": "On The Third Hill",
                  "Prem3": "Down The Fourth Lane",
-            }, "A House On The Third Hill"),
+            }, "A House, On The Third Hill"),
             ({
                  "Prem1": "",
                  "Prem2": "A Second House",
                  "Prem3": "On The Third Hill",
                  "Prem4": "Down The Fourth Lane",
-             }, "A Second House On The Third Hill"),
+             }, "A Second House, On The Third Hill"),
+            ({
+                 "Prem1": "",
+                 "Prem2": "",
+                 "Prem3": "",
+                 "Prem4": "Another House",
+                 "District": "",
+                 "PostTown": "",
+                 "Postcode": "AA1 2BB"
+             }, "Another House, AA1 2BB"),
+            ({
+                 "Prem1": "",
+                 "Prem2": "",
+                 "Prem3": "",
+                 "Prem4": "Another House",
+                 "District": "",
+                 "PostTown": "In Brizzle",
+                 "Postcode": ""
+             }, "Another House, In Brizzle"),
+            ({
+                 "Prem1": "",
+                 "Prem2": "",
+                 "Prem3": "",
+                 "Prem4": "Another House",
+                 "District": "In The Shire",
+                 "PostTown": "",
+                 "Postcode": ""
+             }, "Another House, In The Shire"),
         ]:
             self.assertEqual(eq.EqPayloadConstructor.build_display_address(attributes), expected)
 


### PR DESCRIPTION
# Motivation and Context
Change the display address to contain 'district', 'post_town',
'postcode' if present and 2 fields haven't already been populated. Also
comma separating


# What has changed
Add 'district', 'post_town', 'postcode' to display address
Comma separating address

# How to test?
Run unit tests

# Links
https://trello.com/c/DKeaOOEE/178-send-address-and-country-code-to-eq-from-rh-5

# Screenshots (if appropriate):