### PR TITLE
Revert config changes to smoke and add local flag

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -67,12 +67,12 @@ def test(ctx, clean=False):
 
 
 @task
-def smoke(ctx, clean=False):
+def smoke(ctx, local=False):
     """Run the smoke tests."""
     import pytest
 
-    if clean:
-        cleanpy(ctx)
+    if local:
+        os.environ['RESPONDENT_HOME_URL'] = "http://localhost:9092"
     retcode = pytest.main(["tests/smoke"])
     sys.exit(retcode)
 

--- a/tests/smoke/test_respondent_home.py
+++ b/tests/smoke/test_respondent_home.py
@@ -8,9 +8,9 @@ class TestRespondentHome(unittest.TestCase):
 
     def test_can_access_respondent_home_homepage(self):
         # Given
-        url = os.getenv('ACCOUNT_SERVICE_URL')
+        url = os.getenv('RESPONDENT_HOME_URL')
         if not url:
-            self.fail('ACCOUNT_SERVICE_URL not set')
+            self.fail('RESPONDENT_HOME_URL not set')
 
         # When
         resp = requests.get(url, verify=False)
@@ -21,9 +21,9 @@ class TestRespondentHome(unittest.TestCase):
 
     def test_can_access_required_services(self):
         # Given
-        url = os.getenv('ACCOUNT_SERVICE_URL')
+        url = os.getenv('RESPONDENT_HOME_URL')
         if not url:
-            self.fail('ACCOUNT_SERVICE_URL not set')
+            self.fail('RESPONDENT_HOME_URL not set')
 
         # When
         resp = requests.get(f'{url}/info?check=true', verify=False).json()


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The pipeline [defines a single environment variable](https://github.com/ONSdigital/ras-deploy/blob/f2d650b9c8a5a665eb72f23c63ba1b5b026d1104/pipelines/respondent-home-ui.yml#L121) for the RH smoke test called RESPONDENT_HOME_URL, the incorrect assumption in #38 was made that the rest of the application's environment was available to the smoke test. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Revert back to using RESPONDENT_HOME_URL and add a `--local` flag to `inv smoke`.
