### PR TITLE
Added a respondent_id to the JWT claims

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -54,7 +54,7 @@ def format_date(string_date):
 
 def build_response_id(case_id, collex_id, iac):
     """
-    Builds a response_id from a case, a collection exercise
+    Builds a response_id from a case ID, a collection exercise ID, and an IAC
     :param case_id: a case UUID
     :param collex_id: a collection exercise UUID
     :param iac: an IAC
@@ -85,8 +85,8 @@ class EqPayloadConstructor(object):
         self._tx_id = str(uuid4())
         self._account_service_url = app["ACCOUNT_SERVICE_URL"]
 
-        if iac is None:
-            raise InvalidEqPayLoad("No iac supplied")
+        if not iac:
+            raise InvalidEqPayLoad("IAC is empty or not supplied")
 
         self._iac = iac
 

--- a/app/eq.py
+++ b/app/eq.py
@@ -86,7 +86,7 @@ class EqPayloadConstructor(object):
         self._account_service_url = app["ACCOUNT_SERVICE_URL"]
 
         if not iac:
-            raise InvalidEqPayLoad("IAC is empty or not supplied")
+            raise InvalidEqPayLoad("IAC is empty")
 
         self._iac = iac
 

--- a/app/eq.py
+++ b/app/eq.py
@@ -1,5 +1,7 @@
 import logging
 import time
+import hashlib
+import base64
 from collections import namedtuple
 from uuid import uuid4
 
@@ -50,9 +52,26 @@ def format_date(string_date):
         raise InvalidEqPayLoad(f"Unable to format {string_date}")
 
 
+def build_response_id(case_id, collex_id, iac):
+    """
+    Builds a response_id from a case, a collection exercise
+    :param case_id: a case UUID
+    :param collex_id: a collection exercise UUID
+    :param iac: an IAC
+    :return: a base-64 encoded sha-256 hash of case_id|collex_id|iac
+    """
+    hash_string = f'{case_id}|{collex_id}|{iac}'
+    m = hashlib.sha256()
+    m.update(hash_string.encode('utf-8'))
+
+    logger.debug("Hash created", digest=m.hexdigest(), case_id=case_id, collex_id=collex_id)
+
+    return base64.urlsafe_b64encode(m.digest()).decode()
+
+
 class EqPayloadConstructor(object):
 
-    def __init__(self, case: dict, app: Application):
+    def __init__(self, case: dict, app: Application, iac: str):
         """
         Creates the payload needed to communicate with EQ, built from the Case, Collection Exercise, Sample,
         and Collection Instrument services
@@ -65,6 +84,11 @@ class EqPayloadConstructor(object):
 
         self._tx_id = str(uuid4())
         self._account_service_url = app["ACCOUNT_SERVICE_URL"]
+
+        if iac is None:
+            raise InvalidEqPayLoad("No iac supplied")
+
+        self._iac = iac
 
         try:
             self._case_id = case["id"]
@@ -154,6 +178,8 @@ class EqPayloadConstructor(object):
         except KeyError:
             raise InvalidEqPayLoad(f"Could not retrieve country_code for case {self._case_id}")
 
+        response_id = build_response_id(self._case_id, self._collex_id, self._iac)
+
         # TODO: Remove hardcoded language variables for payload when they become available in RAS/RM
         self._language_code = 'en'  # sample attributes do not currently have language details
 
@@ -175,6 +201,7 @@ class EqPayloadConstructor(object):
             "country_code": self._country_code,
             "language_code": self._language_code,  # currently only 'en' or 'cy'
             "display_address": self.build_display_address(self._sample_attributes),
+            "response_id": response_id
         }
 
         # Add all of the sample attributes to the payload as camel case fields

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -89,7 +89,7 @@ async def post_index(request):
         flash(request, BAD_RESPONSE_MSG)
         return aiohttp_jinja2.render_template("index.html", request, {})
 
-    eq_payload = await EqPayloadConstructor(case, request.app).build()
+    eq_payload = await EqPayloadConstructor(case, request.app, iac).build()
 
     token = encrypt(eq_payload, key_store=request.app['key_store'], key_purpose="authentication")
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -114,7 +114,7 @@ class TestRespondentHome(AioHTTPTestCase):
         if iacs is None:
             self.fail('No IACs for case found')
 
-        iac = iacs[0]['iac']   # Grab the first IAC
+        iac = iacs[0]['iac']
         iac1, iac2, iac3 = iac[:4], iac[4:8], iac[8:]
         form_data = {
             'iac1': iac1, 'iac2': iac2, 'iac3': iac3, 'action[save_continue]': '',

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -136,6 +136,7 @@ def skip_encrypt(func, *args, **kwargs):
 class RHTestCase(AioHTTPTestCase):
 
     language_code = 'en'
+    response_id = '6tg2s16T1HClxcttXW3IJgpe198BuJkGE5oJg0dieOU='
 
     start_date = '2018-04-10'
     end_date = '2020-05-31'
@@ -242,7 +243,7 @@ class RHTestCase(AioHTTPTestCase):
             "country": self.sample_attributes_json['attributes']['COUNTRY'],
             "country_code": self.sample_attributes_json['attributes']['COUNTRY'],
             "reference": self.sample_attributes_json['attributes']['REFERENCE'],
-            "response_id": build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)
+            "response_id": self.response_id
         }
 
         self.case_url = (

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -6,6 +6,7 @@ import uuid
 from aiohttp.test_utils import AioHTTPTestCase
 
 from app.app import create_app
+from app.eq import build_response_id
 
 
 def skip_build_eq(func, *args, **kwargs):
@@ -240,7 +241,8 @@ class RHTestCase(AioHTTPTestCase):
             "tla": self.sample_attributes_json['attributes']['TLA'],
             "country": self.sample_attributes_json['attributes']['COUNTRY'],
             "country_code": self.sample_attributes_json['attributes']['COUNTRY'],
-            "reference": self.sample_attributes_json['attributes']['REFERENCE']
+            "reference": self.sample_attributes_json['attributes']['REFERENCE'],
+            "response_id": build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)
         }
 
         self.case_url = (

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -24,7 +24,7 @@ class TestEq(RHTestCase):
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
             eq.EqPayloadConstructor(self.case_json, self.app, iac_code)
-        self.assertIn('IAC is empty or not supplied', ex.exception.message)
+        self.assertIn('IAC is empty', ex.exception.message)
 
     def test_create_eq_constructor_missing_case_id(self):
         from app import eq
@@ -395,3 +395,11 @@ class TestEq(RHTestCase):
         response_id = build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)
 
         self.assertEqual(response_id, self.eq_payload['response_id'])
+
+    def test_build_response_id_is_unique_by_iac(self):
+        iac = 'A' * 12
+
+        existing_response_id = build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)
+        response_id = build_response_id(self.case_id, self.collection_exercise_id, iac)
+
+        self.assertNotEqual(existing_response_id, response_id)

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -15,7 +15,16 @@ class TestEq(RHTestCase):
     def test_create_eq_constructor(self):
         from app import eq
 
-        self.assertIsInstance(eq.EqPayloadConstructor(self.case_json, self.app), eq.EqPayloadConstructor)
+        self.assertIsInstance(eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code), eq.EqPayloadConstructor)
+
+    def test_create_eq_constructor_missing_iac(self):
+        from app import eq
+
+        iac_code = ''
+
+        with self.assertRaises(InvalidEqPayLoad) as ex:
+            eq.EqPayloadConstructor(self.case_json, self.app, iac_code)
+        self.assertIn('IAC is empty or not supplied', ex.exception.message)
 
     def test_create_eq_constructor_missing_case_id(self):
         from app import eq
@@ -24,7 +33,7 @@ class TestEq(RHTestCase):
         del case_json['id']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app)
+            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn('No case id in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_case_ref(self):
@@ -34,7 +43,7 @@ class TestEq(RHTestCase):
         del case_json['caseRef']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app)
+            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn('No case ref in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_sample_unit_ref(self):
@@ -44,7 +53,7 @@ class TestEq(RHTestCase):
         del case_json['caseGroup']['sampleUnitRef']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app)
+            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn(f'Could not retrieve sample unit ref for case {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_ci_id(self):
@@ -54,7 +63,7 @@ class TestEq(RHTestCase):
         del case_json['collectionInstrumentId']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app)
+            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn(f'No collectionInstrumentId value for case id {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_ce_id(self):
@@ -64,7 +73,7 @@ class TestEq(RHTestCase):
         del case_json["caseGroup"]["collectionExerciseId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app)
+            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn(f'No collection id for case id {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_sample_unit_id(self):
@@ -74,7 +83,7 @@ class TestEq(RHTestCase):
         del case_json["sampleUnitId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app)
+            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn(f'No sample unit id for case {self.case_id}', ex.exception.message)
 
     @unittest_run_loop
@@ -95,7 +104,7 @@ class TestEq(RHTestCase):
                 mocked.get(self.survey_url, payload=self.survey_json)
 
                 with self.assertLogs('app.eq', 'INFO') as cm:
-                    payload = await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                    payload = await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
                 self.assertLogLine(cm, '', payload=payload)
 
         mocked_uuid4.assert_called()
@@ -113,7 +122,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Collection instrument {self.collection_instrument_id} type is not EQ", ex.exception.message)
 
     @unittest_run_loop
@@ -127,7 +136,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"No Collection Instrument type for {self.collection_instrument_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -141,7 +150,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve classifiers for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -155,7 +164,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve eq_id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -169,7 +178,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve form_type for eq_id {self.eq_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -184,7 +193,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve period id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -199,7 +208,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve ce id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -216,7 +225,7 @@ class TestEq(RHTestCase):
             mocked.get(self.sample_attributes_url, payload=sample_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve ru_name (address) for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -233,7 +242,7 @@ class TestEq(RHTestCase):
             mocked.get(self.sample_attributes_url, payload=sample_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve country_code for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -250,7 +259,7 @@ class TestEq(RHTestCase):
             mocked.get(self.sample_attributes_url, payload=sample_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app).build()
+                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f'Could not retrieve attributes for case {self.case_id}', ex.exception.message)
 
     def test_find_event_date_by_tag(self):

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -397,9 +397,9 @@ class TestEq(RHTestCase):
         self.assertEqual(response_id, self.eq_payload['response_id'])
 
     def test_build_response_id_is_unique_by_iac(self):
-        iac = 'A' * 12
+        different_iac = 'A' * 12
 
-        existing_response_id = build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)
-        response_id = build_response_id(self.case_id, self.collection_exercise_id, iac)
+        response_id = build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)
+        different_response_id = build_response_id(self.case_id, self.collection_exercise_id, different_iac)
 
-        self.assertNotEqual(existing_response_id, response_id)
+        self.assertNotEqual(different_response_id, response_id)

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -4,7 +4,7 @@ from unittest import mock
 from aiohttp.test_utils import unittest_run_loop
 from aioresponses import aioresponses
 
-from app.eq import format_date, find_event_date_by_tag
+from app.eq import format_date, find_event_date_by_tag, build_response_id
 from app.exceptions import InvalidEqPayLoad
 
 from . import RHTestCase
@@ -390,3 +390,8 @@ class TestEq(RHTestCase):
 
         # Then an InvalidEqPayLoad is raised
         self.assertEqual(e.exception.message, 'Unable to format invalid_date')
+
+    def test_build_response_id(self):
+        response_id = build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)
+
+        self.assertEqual(response_id, self.eq_payload['response_id'])


### PR DESCRIPTION
**Do not merge until confirmation of eQ changes for this PR**

It's a SHA256 hash of case_id|collex_id|iac

Addressed Jamie's (verbal) PR comments

- added logging & doc string to build_response_id

# Motivation and Context
In order for issuing new IACs to be an information safe operation, activating EQ with a new IAC must launch a new version of the survey questionnaire and not show any previously entered responses.  Currently EQ use the case to identify the responses to be displayed.  Where there are multiple response sets for a case (e.g. where a new IAC has been issued), this is insufficient.  This PR adds an additional field to the JWT claims that go to EQ: response_id.  

# What has changed
- added a build_response_id function to eq.py
- added response_id field to JWT payload 

# How to test?
- navigate to RH
- enter valid IAC into RH
- confirm EQ is correctly launched
- check logs to ensure response_id is populated in the jwt payload (cat logfile | grep payload)

# Links
[schema PR](https://github.com/ONSdigital/ons-schema-definitions/pull/36)

# Screenshots (if appropriate):