### PR TITLE
update the "cookies and privacy" link to point to the correct location

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -62,7 +62,7 @@
                             <a href="https://www.ons.gov.uk/aboutus/contactus" class="footer__link footer__link--inline" target="_blank">Contact us</a>
                         </li>
                         <li>
-                            <a href="https://www.ons.gov.uk/help/cookiesandprivacy" class="footer__link footer__link--inline" target="_blank">Cookies and privacy</a>
+                            <a href="https://surveys.ons.gov.uk/cookies-privacy" class="footer__link footer__link--inline" target="_blank">Cookies and privacy</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
# Motivation and Context
The "Cookies and privacy" link should point to https://surveys.ons.gov.uk/cookies-privacy as the information in more relevant/GDPR compliant

# What has changed
The "Cookies and privacy" link

# How to test?
link should now go to https://surveys.ons.gov.uk/cookies-privacy
