### PR TITLE
Add python3-dev install for smoke test

### DIFF
--- a/ci/smoke_tests.sh
+++ b/ci/smoke_tests.sh
@@ -5,5 +5,6 @@ cd respondent-home-ui-source
 
 # Install libssl-dev for python cryptography lib
 apt-get install libssl-dev -y
+apt-get install python3-dev -y
 pipenv install --dev
 pipenv run inv smoke


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After a recent merge to master on this repo, the smoke test script was failing in the pipeline when running `pipenv install --dev` during an install of the pyyaml package. The error was as follows:

```
    ext/_yaml.c:4:10: fatal error: Python.h: No such file or directory
     #include "Python.h"
              ^~~~~~~~~~
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```       


# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Added an install for python3-dev before pipenv runs.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* I have connected to the failing container in the pipeline and run the script manually and the smoke tests are able to run successfully. You can follow the same steps [here](https://github.com/ONSdigital/ras-deploy#job-failed-in-pipeline) to do the same.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):