### PR TITLE
Add security headers and nonce check to Respondent Home

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -23,8 +23,7 @@ async def get_index(request, msg=None, redirect=False):
     if redirect:
         raise HTTPFound("/")
 
-    response = aiohttp_jinja2.render_template("index.html", request, {})
-    return response
+    return aiohttp_jinja2.render_template("index.html", request, {})
 
 
 async def get_info(request):

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,53 @@
+import random
+import string
+
+from aiohttp import web
+
+
+DEFAULT_RESPONSE_HEADERS = {
+    'Strict-Transport-Security': ['max-age=31536000', 'includeSubDomains'],
+    'Content-Security-Policy': {
+        'default-src': ["'self'", 'https://cdn.ons.gov.uk'],
+        'font-src': ["'self'", 'data:', 'https://cdn.ons.gov.uk'],
+        'script-src': ["'self'", 'https://www.google-analytics.com', 'https://cdn.ons.gov.uk'],
+        'connect-src': ["'self'", 'https://www.google-analytics.com', 'https://cdn.ons.gov.uk'],
+        'img-src': ["'self'", 'data:', 'https://www.google-analytics.com', 'https://cdn.ons.gov.uk'],
+    },
+    'X-XSS-Protection': '1',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'same-origin',
+}
+
+ADD_NONCE_SECTIONS = ['script-src', ]
+
+
+rnd = random.SystemRandom()
+
+
+def get_random_string(length):
+    allowed_chars = (
+            string.ascii_lowercase +
+            string.ascii_uppercase +
+            string.digits)
+    return ''.join(
+        rnd.choice(allowed_chars)
+        for _ in range(length))
+
+
+@web.middleware
+async def nonce_middleware(request, handler):
+    request.csp_nonce = get_random_string(16)
+    return await handler(request)
+
+
+async def on_prepare(request: web.BaseRequest, response: web.StreamResponse):
+    for header, value in DEFAULT_RESPONSE_HEADERS.items():
+        if isinstance(value, dict):
+            value = '; '.join([
+                f"{section} {' '.join(content)} 'nonce-{request.csp_nonce}'"
+                if section in ADD_NONCE_SECTIONS else
+                f"{section} {' '.join(content)}"
+                for section, content in value.items()])
+        elif not isinstance(value, str):
+            value = ' '.join(value)
+        response.headers[header] = value

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,7 +17,7 @@
     <script src="/js/polyfills.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"></script>
   <![endif]-->
   <!--[if gt IE 8]><!-->
-  <script>document.documentElement.className = document.documentElement.className.replace('no-js', 'has-js')</script>
+  <script nonce="{{ request.csp_nonce }}">document.documentElement.className = document.documentElement.className.replace('no-js', 'has-js')</script>
   <!--<![endif]-->
   <!--[if (gt IE 9) | (IEMobile)]><!-->
   <link href="{{ static('css/responsive.css') }}" rel="stylesheet">
@@ -86,7 +86,7 @@
 <!-- jQuery 2 -->
 <!--[if gte IE 9]><!-->
 <script src="/js/vendor/jquery-2.2.0.min.js"></script>
-<script>window.jQuery || document.write('<script "/js/vendor/jquery-2.2.0.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"><\/script>')</script>
+<script nonce="{{ request.csp_nonce }}">window.jQuery || document.write('<script "/js/vendor/jquery-2.2.0.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"><\/script>')</script>
 <!--<![endif]-->
 <!--[if gte IE 9]><!-->
 <script src="/js/bundle.js"></script>


### PR DESCRIPTION
# Motivation and Context
We need to add some security headers to RH as per OWASP recommendations.

We need to add the following headers:

- `Strict-Transport-Security: max-age=31536000; includeSubDomains` - Enforce all communication over TLS
- `Content-Security-Policy: default-src 'self'` - Mitigate and report XSS attacks. Do we need to allow google analytics?
- `X-XSS-Protection: 1` - Enables XSS filtering (usually default in browsers). If a cross-site scripting attack is detected, the browser will sanitize the page (remove the unsafe parts).
- `X-Content-Type-Options: nosniff` - Prevent mime sniffing
- `Referrer-Policy: same-origin` - Only send referrer information to the same domain

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

- Added a security middleware which inserts a nonce to be checked against when using inline JS.
- Added a signal handler which appends required security headers to each response.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

Largely inspired by [flask-talisman](https://github.com/GoogleCloudPlatform/flask-talisman).