### PR TITLE
Remove text assert for smoke test

### DIFF
--- a/tests/smoke/test_respondent_home.py
+++ b/tests/smoke/test_respondent_home.py
@@ -17,7 +17,6 @@ class TestRespondentHome(unittest.TestCase):
 
         # Then
         self.assertEqual(resp.status_code, 200, resp.status_code)
-        self.assertIn('Welcome to the Online Household Study', resp.text)
 
     def test_can_access_required_services(self):
         # Given


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The pipeline failed to deploy due to a failing smoke test caused by a change in the [HTML text](https://github.com/ONSdigital/respondent-home-ui/blob/3447cc16ac954165c667cca851d57d682ff631e6/app/templates/base.html#L43). 

We agreed that this can be removed in favour of future text changes, to prevent it failing again. The HTTP 200 check when the response is returned should be fine for a smoke test for now.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
`test_respondent_home.py`
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the smoke test in the pipeline after merging.
