### PR TITLE
Render messages based on level

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,12 +1,13 @@
 VERSION = '0.0.1'
 
 
-CONNECTION_ERROR_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "clickable": False}    # NOQA
-REDIRECT_FAILED_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "clickable": False}    # NOQA
-SERVER_ERROR_MSG = {'text': 'There was an error, please enter your access code and try again.', "clickable": True}
+CONNECTION_ERROR_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "level": "ERROR"}    # NOQA
+REDIRECT_FAILED_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "level": "ERROR"}    # NOQA
+SERVER_ERROR_MSG = {'text': 'There was an error, please enter your access code and try again.', "clickable": True, "level": "ERROR"}
+BAD_CODE_MSG = {'text': 'Please enter the 12 character access code provided to you by ONS.', "clickable": True, "level": "ERROR"}  # NOQA
+BAD_RESPONSE_MSG = {'text': 'There was an error, please enter your access code and try again.', "clickable": True, "level": "ERROR"}  # NOQA
+INVALID_CODE_MSG = {'text': 'Invalid access code. Please check your access code and web address to continue.', "clickable": True, "level": "ERROR"}  # NOQA
+NOT_AUTHORIZED_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "level": "ERROR"}  # NOQA
 
-BAD_CODE_MSG = {'text': 'Please enter the 12 character access code provided to you by ONS.', "clickable": True}
-BAD_RESPONSE_MSG = {'text': 'There was an error, please enter your access code and try again.', "clickable": True}
-CODE_USED_MSG = {'text': 'Thank you. We have received a response for your address. No further action is required.\n\nIf you need further assistance, please phone us for free on 0800 085 7376.', "clickable": True}    # NOQA
-INVALID_CODE_MSG = {'text': 'Invalid access code. Please check your access code and web address to continue.', "clickable": True}  # NOQA
-NOT_AUTHORIZED_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "clickable": False}  # NOQA
+CODE_USED_MSG = {'text': 'Thank you. We have received a response for your address. No further action is required.\nIf you need further assistance, please phone us for free on 0800 085 7376.', "level": "INFO"}    # NOQA
+CLOSED_CE_MSG = {'text': 'This study is now closed. Thanks you for your interest in participating.', "level": "INFO"}  # NOQA

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,4 +10,4 @@ INVALID_CODE_MSG = {'text': 'Invalid access code. Please check your access code 
 NOT_AUTHORIZED_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "level": "ERROR"}  # NOQA
 
 CODE_USED_MSG = {'text': 'Thank you. We have received a response for your address. No further action is required.\nIf you need further assistance, please phone us for free on 0800 085 7376.', "level": "INFO"}    # NOQA
-CLOSED_CE_MSG = {'text': 'This study is now closed. Thanks you for your interest in participating.', "level": "INFO"}  # NOQA
+CLOSED_CE_MSG = {'text': 'This study is now closed. Thank you for your interest in participating.', "level": "INFO"}  # NOQA

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -62,7 +62,7 @@ async def post_index(request):
         iac_json = await get_iac_details(request, iac, client_ip)
     except InvalidIACError:
         logger.info("Attempt to use an invalid access code", client_ip=client_ip)
-        flash(request, INVALID_CODE_MSG)
+        flash(request, BAD_CODE_MSG)
         return aiohttp_jinja2.render_template("index.html", request, {}, status=202)
 
     try:

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -22,7 +22,6 @@ async def get_index(request, msg=None, redirect=False):
 
     if redirect:
         raise HTTPFound("/")
-
     return aiohttp_jinja2.render_template("index.html", request, {})
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,6 +8,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta content="" name="description">
   <meta content="width=device-width, initial-scale=1" name="viewport">
+  <title>{% block title %}My Survey{% endblock %}</title>
   <link rel="shortcut icon" href="favicon.ico">
   <!--[if lt IE 9]>
     <script src="/js/vendor/html5shiv.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"></script>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta content="" name="description">
   <meta content="width=device-width, initial-scale=1" name="viewport">
-  <title>{% block title %}My Survey{% endblock %}</title>
+  <title>{% block title %}My Study{% endblock %}</title>
   <link rel="shortcut icon" href="favicon.ico">
   <!--[if lt IE 9]>
     <script src="/js/vendor/html5shiv.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"></script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,75 +1,44 @@
 {% extends "base.html" %}
-{% set messages=get_flashed_messages() %}
-{% block title %}{% if messages|length > 0 %}Error - {{ super() }}{% else %}{{ super() }}{% endif %}{% endblock %}
+{% set messages_dict=dict(get_flashed_messages()|groupby('level')) %}
+{% block title %}{% if 'ERROR' in messages_dict %}Error - {{ super() }}{% else %}{{ super() }}{% endif %}{% endblock %}
 {% block content %}
-{% if messages %}
-  <div class="u-mt-s">
-    <div class="panel panel--error">
-      <div class="panel__header">
-        <h1 class="panel__title venus">
-          {% trans count=messages|length %}
-            This page has an error
-            {% pluralize %}
-            This page has {{ count }} errors
-          {% endtrans %}
-        </h1>
-      </div>
-      <div class="panel__body">
-        <p class="mars">
-        {% trans count=messages|length %}
-        This <strong>must be corrected</strong> to continue.
-        {% pluralize %}
-        These <strong>must be corrected</strong> to continue.
-        {% endtrans %}
-        </p>
-        <ul class="list list--bare">
-          {% for message in messages %}
-          <li class="list__item mars">{{ loop.index }})
-            {% if message.clickable %}
-              <a class="js-inpagelink" href="#census-access-code-answer">{{ message.text }}</a>
-            {% else %}
-              {{ message.text }}
-            {% endif %}
-          </li>
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
-  </div>
-{% endif %}
-<div>
-<h2 class="saturn u-mt-l u-mb-m">Please enter your 12 character access code</h2>
-  <form action="/" class="form qa-questionnaire-form" role="form" method="post" novalidate="">
-    <div class="panel panel--simple panel--spacious {% if messages %} panel--error {% else %} panel--info {% endif %} u-mb-l">
-      <div class="panel__body">
-        <div class="group" id="household-and-accommodation">
-          <div class="block" id="census-access-code">
-            <div class="section" id="census-access-code-section">
-              <div class="question" id="census-access-code-question">
-                <div class="question__answers">
-                  <div class="question__answer">
-                    <div class="answer answer--integer " id="census-access-code-answer">
-                      <div class="answer__fields js-fields">
-                        <fieldset class="fieldgroup fieldgroup--date">
-                          <legend class="fieldgroup__title venus">Your access code is printed on the letter we sent you</legend>
-                          <div class="fieldgroup__fields">
-                            <div class="field field--input field--code">
-                              <label class="label mercury u-vh" for="iac1">Enter the first four characters of the access code</label>
-                              <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac1" name="iac1" class="input input--text" value=""
-                                type="text" autocomplete="off" required>
+  {% if messages_dict %}
+    {% include "partials/messages.html" with context %}
+  {% endif %}
+  <div>
+  <h2 class="saturn u-mt-l u-mb-m">Please enter your 12 character access code</h2>
+    <form action="/" class="form qa-questionnaire-form" role="form" method="post" novalidate="">
+      <div class="panel panel--simple panel--spacious {% if 'ERROR' in messages_dict %} panel--error {% else %} panel--info {% endif %} u-mb-l">
+        <div class="panel__body">
+          <div class="group" id="household-and-accommodation">
+            <div class="block" id="access-code">
+              <div class="section" id="access-code-section">
+                <div class="question" id="access-code-question">
+                  <div class="question__answers">
+                    <div class="question__answer">
+                      <div class="answer answer--integer " id="access-code-answer">
+                        <div class="answer__fields js-fields">
+                          <fieldset class="fieldgroup fieldgroup--date">
+                            <legend class="fieldgroup__title venus">Your access code is printed on the letter we sent you</legend>
+                            <div class="fieldgroup__fields">
+                              <div class="field field--input field--code">
+                                <label class="label mercury u-vh" for="iac1">Enter the first four characters of the access code</label>
+                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac1" name="iac1" class="input input--text" value=""
+                                  type="text" autocomplete="off" required>
+                              </div>
+                              <div class="field field--select field--code">
+                                <label class="label mercury u-vh" for="iac2">Enter the next four characters of the access code</label>
+                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac2" name="iac2" class="input input--text" value=""
+                                  type="text" autocomplete="off" required>
+                              </div>
+                              <div class="field field--input field--code">
+                                <label class="label mercury u-vh" for="iac3">Enter the last four characters of the access code</label>
+                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac3" name="iac3" class="input input--text" value=""
+                                  type="text" autocomplete="off" required>
+                              </div>
                             </div>
-                            <div class="field field--select field--code">
-                              <label class="label mercury u-vh" for="iac2">Enter the next four characters of the access code</label>
-                              <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac2" name="iac2" class="input input--text" value=""
-                                type="text" autocomplete="off" required>
-                            </div>
-                            <div class="field field--input field--code">
-                              <label class="label mercury u-vh" for="iac3">Enter the last four characters of the access code</label>
-                              <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac3" name="iac3" class="input input--text" value=""
-                                type="text" autocomplete="off" required>
-                            </div>
-                          </div>
-                        </fieldset>
+                          </fieldset>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -79,11 +48,10 @@
           </div>
         </div>
       </div>
-    </div>
-    <div class="lock u-mb-m">
-      <div class="venus lock__text">Your personal information is protected by law and will be kept confidential.</div>
-    </div>    
-    <button class="btn btn--lg qa-btn-get-started" type="submit" name="action[save_continue]">Start now</button>
-  </form>
-</div>
+      <div class="lock u-mb-m">
+        <div class="venus lock__text">Your personal information is protected by law and will be kept confidential.</div>
+      </div>
+      <button class="btn btn--lg qa-btn-get-started" type="submit" name="action[save_continue]">Start now</button>
+    </form>
+  </div>
 {% endblock %}

--- a/app/templates/partials/messages.html
+++ b/app/templates/partials/messages.html
@@ -1,0 +1,49 @@
+{% for group, messages in messages_dict.items() %}
+  <div class="u-mt-s">
+
+    {% if group=='ERROR' %}
+    <div class="panel panel--error">
+      <div class="panel__header">
+        <h1 class="panel__title venus">
+          {% trans count=messages|length %}
+          This page has an error
+          {% pluralize %}
+          This page has {{ count }} errors
+          {% endtrans %}
+        </h1>
+      </div>
+
+      {% for message in messages %}
+      <div class="panel__body">
+        {% if message.clickable %}
+        <p class="mars">
+          This <strong>must be corrected</strong> to continue.
+        </p>
+        {% endif %}
+        <ul class="list list--bare">
+          <li class="list__item mars">{% if group.list|length > 1 %}{{ loop.index }}){% endif %}
+            {% if message.clickable %}
+              <a class="js-inpagelink" href="access-code-answer">{{ message.text }}</a>
+            {% else %}
+              {{ message.text }}
+            {% endif %}
+          </li>
+        </ul>
+      </div>
+      {% endfor %}
+    </div>
+
+    {% elif group=='INFO' %}
+      {% for message in messages %}
+      <div class="panel panel--simple panel--info">
+        <div class="panel__body">
+          {% for para in message.text.split('\n') %}
+            <h2 class="mars">{{ para }}</h2>
+          {% endfor %}
+        </div>
+      </div>
+      {% endfor %}
+    {% endif %}
+
+  </div>
+{% endfor %}

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -179,6 +179,23 @@ class RHTestCase(AioHTTPTestCase):
         else:
             self.fail(f'No matching log records present: {event}')
 
+    def assertMessagePanel(self, message, content):
+        """
+        Helper method for asserting the rendered content includes the required message panels.
+
+        :param message: message dict
+        :param content: rendered HTML str
+        """
+        if message.get('clickable', False):
+            if message['level'] == 'ERROR':
+                self.assertIn('must be corrected', content)
+            self.assertIn('js-inpagelink', content)
+
+        for message_line in message['text'].split('\n'):
+            self.assertIn(message_line, content)
+
+        self.assertIn(f'panel--{message["level"].lower()}', content)
+
     def setUp(self):
         super().setUp()  # NB: setUp the server first so we can use self.app
         with open('tests/test_data/case/case.json') as fp:

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -417,7 +417,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Attempt to use an invalid access code", client_ip=None)
 
         self.assertEqual(response.status, 202)
-        self.assertMessagePanel(INVALID_CODE_MSG, str(await response.content.read()))
+        self.assertMessagePanel(BAD_CODE_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_403(self):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -51,7 +51,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Service connection error")
 
         self.assertEqual(response.status, 200)
-        self.assertIn(CONNECTION_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(CONNECTION_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_no_iac_json(self):
@@ -63,7 +63,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Service failed to return expected JSON payload")
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_case_403(self):
@@ -76,7 +76,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error retrieving case", case_id=self.case_id, status_code=403)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_case_500(self):
@@ -89,7 +89,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error retrieving case", case_id=self.case_id, status_code=500)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_case_connector_error(self):
@@ -102,7 +102,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Service connection error")
 
         self.assertEqual(response.status, 200)
-        self.assertIn(CONNECTION_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(CONNECTION_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_with_build_connection_error(self):
@@ -116,7 +116,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Service connection error", message='Failed')
 
         self.assertEqual(response.status, 200)
-        self.assertIn(CONNECTION_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(CONNECTION_ERROR_MSG, str(await response.content.read()))
 
     @skip_encrypt
     @unittest_run_loop
@@ -165,7 +165,7 @@ class TestHandlers(RHTestCase):
 
         # then error handler catches exception and flashes message to index
         self.assertEqual(response.status, 200)
-        self.assertIn(REDIRECT_FAILED_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(REDIRECT_FAILED_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_with_build_ci_500(self):
@@ -182,7 +182,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error in response", status_code=500)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_with_build_ci_400(self):
@@ -199,7 +199,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error in response", status_code=400)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_with_build_ce_503(self):
@@ -217,7 +217,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error in response", status_code=503)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_with_build_events_404(self):
@@ -236,7 +236,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error in response", status_code=404)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_with_build_sample_403(self):
@@ -256,7 +256,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error in response", status_code=403)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_with_build_case_event_500(self):
@@ -277,7 +277,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error posting case event", status_code=500, case_id=self.case_id)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_caseid_missing(self):
@@ -292,7 +292,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, 'caseId missing from IAC response')
 
         self.assertEqual(response.status, 200)
-        self.assertIn(BAD_RESPONSE_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(BAD_RESPONSE_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_sampleUnitType_missing(self):
@@ -308,7 +308,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, 'sampleUnitType missing from case response')
 
         self.assertEqual(response.status, 200)
-        self.assertIn(BAD_RESPONSE_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(BAD_RESPONSE_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_sampleUnitType_B_error(self):
@@ -324,7 +324,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, 'Attempt to use unexpected sample unit type', sample_unit_type='B')
 
         self.assertEqual(response.status, 200)
-        self.assertIn(INVALID_CODE_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(INVALID_CODE_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_malformed(self):
@@ -339,7 +339,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Attempt to use a malformed access code")
 
         self.assertEqual(response.status, 200)
-        self.assertIn(BAD_CODE_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(BAD_CODE_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_active_missing(self):
@@ -354,7 +354,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Attempt to use an inactive access code")
 
         self.assertEqual(response.status, 200)
-        self.assertIn(CODE_USED_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(CODE_USED_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_inactive(self):
@@ -369,7 +369,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Attempt to use an inactive access code")
 
         self.assertEqual(response.status, 200)
-        self.assertIn(CODE_USED_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(CODE_USED_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_connection_error(self):
@@ -381,7 +381,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Client failed to connect to iac service")
 
         self.assertEqual(response.status, 200)
-        self.assertIn(CONNECTION_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(CONNECTION_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_500(self):
@@ -393,7 +393,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error in response", status_code=500)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_503(self):
@@ -405,7 +405,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Error in response", status_code=503)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(SERVER_ERROR_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(SERVER_ERROR_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_404(self):
@@ -417,7 +417,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Attempt to use an invalid access code", client_ip=None)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(INVALID_CODE_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(INVALID_CODE_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_403(self):
@@ -429,7 +429,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Unauthorized access to IAC service attempted", client_ip=None)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(NOT_AUTHORIZED_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(NOT_AUTHORIZED_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_401(self):
@@ -441,7 +441,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Unauthorized access to IAC service attempted", client_ip=None)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(NOT_AUTHORIZED_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(NOT_AUTHORIZED_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_400(self):
@@ -453,7 +453,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Client error when accessing IAC service", client_ip=None, status=400)
 
         self.assertEqual(response.status, 200)
-        self.assertIn(BAD_RESPONSE_MSG.get('text').encode(), await response.content.read())
+        self.assertMessagePanel(BAD_RESPONSE_MSG, str(await response.content.read()))
 
     def test_join_iac(self):
         # Given some post data


### PR DESCRIPTION
# Motivation and Context
Currently every message flashed is treated as an error. This PR adds the functionality to handle levels of messages and render the related panel type from the pattern library. 

# What has changed

- Adds functionality to respondent home for rendering non-error level messages in templates using the pattern library panels.
- Adds additional field "level" (currently only ERROR or INFO) to the message dicts.
- Adds an HTML partial for handling the message logic and rendering appropriately.
- Adds missing title tag to the base template.
- Use correct error message for an invalid code.

# How to test?
Unit tests:
`make unittests`

Functionality:
1. Start locally and attempt to navigate to respondent home: http://localhost:9092
2. Check the rendered messages against "Message Slides" (attached to Trello card).

![image](https://user-images.githubusercontent.com/28348457/46340492-6e3b2d00-c62d-11e8-8d44-1f4794be58af.png)


NB: WIP as missing tests.