### PR TITLE
If IAC is invalid the response is changed to HTTPAccepted (202)

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -7,3 +7,7 @@ class InvalidEqPayLoad(Exception):
     def __init__(self, message):
         super().__init__()
         self.message = message
+
+
+class InvalidIACError(Exception):
+    """Raised when the IAC Service returns a 404"""

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -2,7 +2,7 @@ import logging
 
 import aiohttp_jinja2
 from aiohttp.client_exceptions import ClientConnectionError, ClientConnectorError, ClientResponseError
-from aiohttp.web import HTTPFound, HTTPAccepted, json_response
+from aiohttp.web import HTTPFound, json_response
 from sdc.crypto.encrypter import encrypt
 from structlog import wrap_logger
 

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -2,7 +2,7 @@ import logging
 
 import aiohttp_jinja2
 from aiohttp.client_exceptions import ClientConnectionError, ClientConnectorError, ClientResponseError
-from aiohttp.web import HTTPFound, json_response
+from aiohttp.web import HTTPFound, HTTPAccepted, json_response
 from sdc.crypto.encrypter import encrypt
 from structlog import wrap_logger
 
@@ -117,7 +117,7 @@ async def get_iac_details(request, iac: str, client_ip: str):
                 if resp.status == 404:
                     logger.info("Attempt to use an invalid access code", client_ip=client_ip)
                     flash(request, INVALID_CODE_MSG)
-                    raise HTTPFound("/")
+                    raise HTTPAccepted()
                 elif resp.status in (401, 403):
                     logger.info("Unauthorized access to IAC service attempted", client_ip=client_ip)
                     flash(request, NOT_AUTHORIZED_MSG)

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -9,7 +9,7 @@ from structlog import wrap_logger
 from . import BAD_CODE_MSG, BAD_RESPONSE_MSG, CODE_USED_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG, VERSION
 from .case import get_case, post_case_event
 from .eq import EqPayloadConstructor
-from .exceptions import InactiveCaseError
+from .exceptions import InactiveCaseError, InvalidIACError
 from .flash import flash
 
 
@@ -59,7 +59,12 @@ async def post_index(request):
             redirect=True,
         )
 
-    iac_json = await get_iac_details(request, iac, client_ip)
+    try:
+        iac_json = await get_iac_details(request, iac, client_ip)
+    except InvalidIACError:
+        logger.info("Attempt to use an invalid access code", client_ip=client_ip)
+        flash(request, INVALID_CODE_MSG)
+        return aiohttp_jinja2.render_template("index.html", request, {}, status=202)
 
     try:
         validate_case(iac_json)
@@ -115,9 +120,7 @@ async def get_iac_details(request, iac: str, client_ip: str):
                 resp.raise_for_status()
             except ClientResponseError as ex:
                 if resp.status == 404:
-                    logger.info("Attempt to use an invalid access code", client_ip=client_ip)
-                    flash(request, INVALID_CODE_MSG)
-                    raise HTTPAccepted()
+                    raise InvalidIACError
                 elif resp.status in (401, 403):
                     logger.info("Unauthorized access to IAC service attempted", client_ip=client_ip)
                     flash(request, NOT_AUTHORIZED_MSG)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -416,8 +416,7 @@ class TestHandlers(RHTestCase):
                 response = await self.client.request("POST", "/", data=self.form_data)
             self.assertLogLine(cm, "Attempt to use an invalid access code", client_ip=None)
 
-        self.assertEqual(response.status, 200)
-        self.assertIn(INVALID_CODE_MSG.get('text').encode(), await response.content.read())
+        self.assertEqual(response.status, 202)
 
     @unittest_run_loop
     async def test_post_index_iac_service_403(self):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -417,6 +417,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Attempt to use an invalid access code", client_ip=None)
 
         self.assertEqual(response.status, 202)
+        self.assertIn(INVALID_CODE_MSG.get('text').encode(), await response.content.read())
 
     @unittest_run_loop
     async def test_post_index_iac_service_403(self):


### PR DESCRIPTION
# Motivation and Context
Respondent Home needs to return a 202 http status code when an IAC code is entered but not found, this is to enable a WAF rule which will block IP's on multiple failed IAC attempts.

# What has changed
If the IAC is invalid the response raised is now HTTPAccepted. Unit test looking for 404 messages from the IAC service is now checking the response is 202.

# How to test?
Run the unit tests.

# Links
https://trello.com/c/Rymy0bKn

# Screenshots (if appropriate):