### PR TITLE
Make URL path prefix configurable

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -89,7 +89,7 @@ def create_app(config_name=None) -> Application:
     logger.info("Logging configured", log_level=app['LOG_LEVEL'])
 
     # Set up routes
-    routes.setup(app, app['URL_PATH_PREFIX'])
+    routes.setup(app, url_path_prefix=app['URL_PATH_PREFIX'])
 
     # Use content negotiation middleware to render JSON responses
     negotiation.setup(app)

--- a/app/app.py
+++ b/app/app.py
@@ -106,8 +106,8 @@ def create_app(config_name=None) -> Application:
 
     # Set static folder location
     # TODO: Only turn on in dev environment
-    app["static_root_url"] = "/"
-    app.router.add_static("/", app["STATIC_ROOT"], show_index=True)
+    app["static_root_url"] = f'{app["URL_PATH_PREFIX"] or "/"}'
+    app.router.add_static(app["static_root_url"], app["STATIC_ROOT"], show_index=True)
 
     # JWT KeyStore
     app["key_store"] = jwt.key_store(app["JSON_SECRET_KEYS"])

--- a/app/app.py
+++ b/app/app.py
@@ -107,7 +107,7 @@ def create_app(config_name=None) -> Application:
     # Set static folder location
     # TODO: Only turn on in dev environment
     app["static_root_url"] = app["URL_PATH_PREFIX"] or "/"
-    app.router.add_static(app["static_root_url"], app["STATIC_ROOT"], show_index=True)
+    app.router.add_static(app["static_root_url"], app["STATIC_ROOT"])
 
     # JWT KeyStore
     app["key_store"] = jwt.key_store(app["JSON_SECRET_KEYS"])

--- a/app/app.py
+++ b/app/app.py
@@ -89,7 +89,7 @@ def create_app(config_name=None) -> Application:
     logger.info("Logging configured", log_level=app['LOG_LEVEL'])
 
     # Set up routes
-    routes.setup(app)
+    routes.setup(app, app['URL_PATH_PREFIX'])
 
     # Use content negotiation middleware to render JSON responses
     negotiation.setup(app)

--- a/app/app.py
+++ b/app/app.py
@@ -106,7 +106,7 @@ def create_app(config_name=None) -> Application:
 
     # Set static folder location
     # TODO: Only turn on in dev environment
-    app["static_root_url"] = f'{app["URL_PATH_PREFIX"] or "/"}'
+    app["static_root_url"] = app["URL_PATH_PREFIX"] or "/"
     app.router.add_static(app["static_root_url"], app["STATIC_ROOT"], show_index=True)
 
     # JWT KeyStore

--- a/app/app.py
+++ b/app/app.py
@@ -6,7 +6,7 @@ import jinja2
 from aiohttp import BasicAuth, ClientSession, ClientTimeout
 from aiohttp.client_exceptions import ClientConnectionError, ClientConnectorError, ClientResponseError
 from aiohttp.web import Application
-from aiohttp_utils import negotiation
+from aiohttp_utils import negotiation, routing
 from structlog import wrap_logger
 
 from . import config
@@ -67,7 +67,8 @@ def create_app(config_name=None) -> Application:
             security.nonce_middleware,
             session.setup(app_config["SECRET_KEY"]),
             flash.flash_middleware,
-        ]
+        ],
+        router=routing.ResourceRouter(),
     )
 
     # Handle 500 errors

--- a/app/config.py
+++ b/app/config.py
@@ -64,6 +64,8 @@ class BaseConfig:
 
     SECRET_KEY = env("SECRET_KEY")
 
+    URL_PATH_PREFIX = env("URL_PATH_PREFIX", default="")
+
 
 class ProductionConfig(BaseConfig):
     pass
@@ -106,6 +108,8 @@ class DevelopmentConfig:
 
     SECRET_KEY = env.str("SECRET_KEY", default=None) or generate_new_key()
 
+    URL_PATH_PREFIX = env("URL_PATH_PREFIX", default="")
+
 
 class TestingConfig:
     HOST = "0.0.0.0"
@@ -136,3 +140,5 @@ class TestingConfig:
     SURVEY_AUTH = ("admin", "secret")
 
     SECRET_KEY = generate_new_key()
+
+    URL_PATH_PREFIX = "/url-path-prefix"

--- a/app/config.py
+++ b/app/config.py
@@ -141,4 +141,4 @@ class TestingConfig:
 
     SECRET_KEY = generate_new_key()
 
-    URL_PATH_PREFIX = "/url-path-prefix"
+    URL_PATH_PREFIX = ""

--- a/app/eq.py
+++ b/app/eq.py
@@ -83,7 +83,7 @@ class EqPayloadConstructor(object):
         self._sample_url = f"{app['SAMPLE_URL']}/samples/"
 
         self._tx_id = str(uuid4())
-        self._account_service_url = app["ACCOUNT_SERVICE_URL"]
+        self._account_service_url = f'{app["ACCOUNT_SERVICE_URL"]}{app["URL_PATH_PREFIX"]}'
 
         if not iac:
             raise InvalidEqPayLoad("IAC is empty")

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -21,7 +21,7 @@ async def get_index(request, msg=None, redirect=False):
         flash(request, msg)
 
     if redirect:
-        raise HTTPFound("/")
+        raise HTTPFound(request.path)
 
     return aiohttp_jinja2.render_template("index.html", request, {})
 

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -2,7 +2,7 @@ import logging
 
 import aiohttp_jinja2
 from aiohttp.client_exceptions import ClientConnectionError, ClientConnectorError, ClientResponseError
-from aiohttp.web import HTTPFound, json_response
+from aiohttp.web import HTTPFound, RouteTableDef, View, json_response
 from sdc.crypto.encrypter import encrypt
 from structlog import wrap_logger
 
@@ -14,131 +14,138 @@ from .flash import flash
 
 
 logger = wrap_logger(logging.getLogger("respondent-home"))
+routes = RouteTableDef()
 
 
-async def get_index(request, msg=None, redirect=False):
-    if msg:
-        flash(request, msg)
+@routes.view('/info', name='info', use_prefix=False)
+class Info(View):
 
-    if redirect:
-        raise HTTPFound(request.app.router['get_index'].url_for())
-
-    return aiohttp_jinja2.render_template("index.html", request, {})
-
-
-async def get_info(request):
-    info = {
-        "name": 'respondent-home-ui',
-        "version": VERSION,
-    }
-    if 'check' in request.query:
-        info["ready"] = await request.app.check_services()
-    return json_response(info)
+    async def get(self):
+        info = {
+            "name": 'respondent-home-ui',
+            "version": VERSION,
+        }
+        if 'check' in self.request.query:
+            info["ready"] = await self.request.app.check_services()
+        return json_response(info)
 
 
-def join_iac(data, expected_length=12):
-    combined = "".join([v.lower() for v in data.values()][:3])
-    if len(combined) < expected_length:
-        raise TypeError
-    return combined
+@routes.view('/', name='index')
+class Index(View):
 
+    def __init__(self, request):
+        super(Index, self).__init__(request)
+        self.client_ip = self.request.headers.get("X-Forwarded-For")
+        self.iac = None
 
-async def post_index(request):
-    """
-    Main entry point to building an eQ payload as URL parameter.
-    """
-    client_ip = request.headers.get("X-Forwarded-For")
-    data = await request.post()
-    try:
-        iac = join_iac(data)
-    except TypeError:
-        logger.warn("Attempt to use a malformed access code", client_ip=client_ip)
-        return await get_index(
-            request,
-            msg=BAD_CODE_MSG,
-            redirect=True,
-        )
+    @property
+    def iac_url(self):
+        return f"{self.request.app['IAC_URL']}/iacs/{self.iac}"
 
-    try:
-        iac_json = await get_iac_details(request, iac, client_ip)
-    except InvalidIACError:
-        logger.info("Attempt to use an invalid access code", client_ip=client_ip)
-        flash(request, BAD_CODE_MSG)
-        return aiohttp_jinja2.render_template("index.html", request, {}, status=202)
+    @staticmethod
+    def join_iac(data, expected_length=12):
+        combined = "".join([v.lower() for v in data.values()][:3])
+        if len(combined) < expected_length:
+            raise TypeError
+        return combined
 
-    try:
-        validate_case(iac_json)
-    except InactiveCaseError:
-        logger.info("Attempt to use an inactive access code", client_ip=client_ip)
-        flash(request, CODE_USED_MSG)
-        return aiohttp_jinja2.render_template("index.html", request, {})
+    @staticmethod
+    def validate_case(case_json):
+        if not case_json.get("active", False):
+            raise InactiveCaseError
 
-    try:
-        case_id = iac_json["caseId"]
-    except KeyError:
-        logger.error('caseId missing from IAC response', client_ip=client_ip)
-        flash(request, BAD_RESPONSE_MSG)
-        return aiohttp_jinja2.render_template("index.html", request, {})
+    def redirect(self):
+        raise HTTPFound(self.request.app.router['index'].url_for())
 
-    case = await get_case(case_id, request.app)
+    async def get_iac_details(self):
+        logger.info(f"Making GET request to {self.iac_url}", iac=self.iac, client_ip=self.client_ip)
+        try:
+            async with self.request.app.http_session_pool.get(self.iac_url, auth=self.request.app["IAC_AUTH"]) as resp:
+                logger.info("Received response from IAC", iac=self.iac, status_code=resp.status)
 
-    try:
-        assert case['sampleUnitType'] == 'H'
-    except AssertionError:
-        logger.error('Attempt to use unexpected sample unit type', sample_unit_type=case['sampleUnitType'])
-        flash(request, INVALID_CODE_MSG)
-        return aiohttp_jinja2.render_template("index.html", request, {})
-    except KeyError:
-        logger.error('sampleUnitType missing from case response', client_ip=client_ip)
-        flash(request, BAD_RESPONSE_MSG)
-        return aiohttp_jinja2.render_template("index.html", request, {})
-
-    eq_payload = await EqPayloadConstructor(case, request.app, iac).build()
-
-    token = encrypt(eq_payload, key_store=request.app['key_store'], key_purpose="authentication")
-
-    description = f"Instrument LMS launched for case {case_id}"
-    await post_case_event(case_id, 'EQ_LAUNCH', description, request.app)
-
-    logger.info('Redirecting to eQ', client_ip=client_ip)
-    raise HTTPFound(f"{request.app['EQ_URL']}/session?token={token}")
-
-
-def validate_case(case_json):
-    if not case_json.get("active", False):
-        raise InactiveCaseError
-
-
-async def get_iac_details(request, iac: str, client_ip: str):
-    iac_url = f"{request.app['IAC_URL']}/iacs/{iac}"
-    logger.info(f"Making GET request to {iac_url}", iac=iac, client_ip=client_ip)
-    try:
-        async with request.app.http_session_pool.get(iac_url, auth=request.app["IAC_AUTH"]) as resp:
-            logger.info("Received response from IAC", iac=iac, status_code=resp.status)
-            index = request.app.router['get_index'].url_for()
-
-            try:
-                resp.raise_for_status()
-            except ClientResponseError as ex:
-                if resp.status == 404:
-                    raise InvalidIACError
-                elif resp.status in (401, 403):
-                    logger.info("Unauthorized access to IAC service attempted", client_ip=client_ip)
-                    flash(request, NOT_AUTHORIZED_MSG)
-                    raise HTTPFound(index)
-                elif 400 <= resp.status < 500:
-                    logger.info(
-                        "Client error when accessing IAC service",
-                        client_ip=client_ip,
-                        status=resp.status,
-                    )
-                    flash(request, BAD_RESPONSE_MSG)
-                    raise HTTPFound(index)
+                try:
+                    resp.raise_for_status()
+                except ClientResponseError as ex:
+                    if resp.status == 404:
+                        raise InvalidIACError
+                    elif resp.status in (401, 403):
+                        logger.info("Unauthorized access to IAC service attempted", client_ip=self.client_ip)
+                        flash(self.request, NOT_AUTHORIZED_MSG)
+                        return self.redirect()
+                    elif 400 <= resp.status < 500:
+                        logger.info(
+                            "Client error when accessing IAC service",
+                            client_ip=self.client_ip,
+                            status=resp.status,
+                        )
+                        flash(self.request, BAD_RESPONSE_MSG)
+                        return self.redirect()
+                    else:
+                        logger.error("Error in response", url=resp.url, status_code=resp.status)
+                        raise ex
                 else:
-                    logger.error("Error in response", url=resp.url, status_code=resp.status)
-                    raise ex
-            else:
-                return await resp.json()
-    except (ClientConnectionError, ClientConnectorError) as ex:
-        logger.error("Client failed to connect to iac service", client_ip=client_ip)
-        raise ex
+                    return await resp.json()
+        except (ClientConnectionError, ClientConnectorError) as ex:
+            logger.error("Client failed to connect to iac service", client_ip=self.client_ip)
+            raise ex
+
+    @aiohttp_jinja2.template('index.html')
+    async def get(self):
+        return {}
+
+    @aiohttp_jinja2.template('index.html')
+    async def post(self):
+        """
+        Main entry point to building an eQ payload as URL parameter.
+        """
+        data = await self.request.post()
+        try:
+            self.iac = self.join_iac(data)
+        except TypeError:
+            logger.warn("Attempt to use a malformed access code", client_ip=self.client_ip)
+            flash(self.request, BAD_CODE_MSG)
+            return self.redirect()
+
+        try:
+            iac_json = await self.get_iac_details()
+        except InvalidIACError:
+            logger.info("Attempt to use an invalid access code", client_ip=self.client_ip)
+            flash(self.request, BAD_CODE_MSG)
+            return aiohttp_jinja2.render_template("index.html", self.request, {}, status=202)
+
+        try:
+            self.validate_case(iac_json)
+        except InactiveCaseError:
+            logger.info("Attempt to use an inactive access code", client_ip=self.client_ip)
+            flash(self.request, CODE_USED_MSG)
+            return {}
+
+        try:
+            case_id = iac_json["caseId"]
+        except KeyError:
+            logger.error('caseId missing from IAC response', client_ip=self.client_ip)
+            flash(self.request, BAD_RESPONSE_MSG)
+            return {}
+
+        case = await get_case(case_id, self.request.app)
+
+        try:
+            assert case['sampleUnitType'] == 'H'
+        except AssertionError:
+            logger.error('Attempt to use unexpected sample unit type', sample_unit_type=case['sampleUnitType'])
+            flash(self.request, INVALID_CODE_MSG)
+            return {}
+        except KeyError:
+            logger.error('sampleUnitType missing from case response', client_ip=self.client_ip)
+            flash(self.request, BAD_RESPONSE_MSG)
+            return {}
+
+        eq_payload = await EqPayloadConstructor(case, self.request.app, self.iac).build()
+
+        token = encrypt(eq_payload, key_store=self.request.app['key_store'], key_purpose="authentication")
+
+        description = f"Instrument LMS launched for case {case_id}"
+        await post_case_event(case_id, 'EQ_LAUNCH', description, self.request.app)
+
+        logger.info('Redirecting to eQ', client_ip=self.client_ip)
+        raise HTTPFound(f"{self.request.app['EQ_URL']}/session?token={token}")

--- a/app/routes.py
+++ b/app/routes.py
@@ -13,9 +13,9 @@ ROUTES = [
 ]
 
 
-def setup(app, url_prefix=""):
+def setup(app, url_path_prefix):
     """Set up routes."""
     for route in ROUTES:
         method, url, handler, name = route
-        full_url = f"/{url.lstrip('/')}"
+        full_url = f"{url_path_prefix}/{url.lstrip('/')}"
         app.router.add_route(method, full_url, handler, name=name)

--- a/app/routes.py
+++ b/app/routes.py
@@ -15,8 +15,9 @@ ROUTES = [
 
 def setup(app, url_path_prefix):
     """Set up routes. Preserve /info for app health check"""
+    prefix = url_path_prefix.lstrip("/")
     for route in ROUTES:
         method, url, handler, name = route
         url = url.lstrip('/')
-        full_url = f"{url_path_prefix}/{url}" if name != "get_info" else f"/{url}"
+        full_url = f"/{prefix}{url}" if name != "get_info" else f"/{url}"
         app.router.add_route(method, full_url, handler, name=name)

--- a/app/routes.py
+++ b/app/routes.py
@@ -14,8 +14,9 @@ ROUTES = [
 
 
 def setup(app, url_path_prefix):
-    """Set up routes."""
+    """Set up routes. Preserve /info for app health check"""
     for route in ROUTES:
         method, url, handler, name = route
-        full_url = f"{url_path_prefix}/{url.lstrip('/')}"
+        url = url.lstrip('/')
+        full_url = f"{url_path_prefix}/{url}" if name != "get_info" else f"/{url}"
         app.router.add_route(method, full_url, handler, name=name)

--- a/app/routes.py
+++ b/app/routes.py
@@ -3,8 +3,8 @@ from .handlers import routes
 
 def setup(app, url_path_prefix):
     """Set up routes."""
-    prefix = url_path_prefix.lstrip("/")
     for route in routes:
-        url = route.path.lstrip('/')
-        route_path = f"/{prefix}{url}" if route.kwargs.get('use_prefix', True) else f"/{url}"
+        path = route.path.lstrip('/')
+        path = f'/{path}' if path else ''
+        route_path = f'{url_path_prefix}{path}' if route.kwargs.get('use_prefix', True) else path
         app.router.add_route(route.method, route_path, route.handler, name=route.kwargs.get('name'))

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,10 +1,11 @@
+from aiohttp_utils.routing import add_resource_context
+
 from .handlers import routes
 
 
 def setup(app, url_path_prefix):
-    """Set up routes."""
+    """Set up routes as resources so we can use the `Index:get` notation for URL lookup."""
     for route in routes:
-        path = route.path.lstrip('/')
-        path = f'/{path}' if path else ''
-        route_path = f'{url_path_prefix}{path}' if route.kwargs.get('use_prefix', True) else path
-        app.router.add_route(route.method, route_path, route.handler, name=route.kwargs.get('name'))
+        prefix = url_path_prefix if route.kwargs.get('use_prefix', True) else ''
+        with add_resource_context(app, module='app.handlers', url_prefix=prefix) as new_route:
+            new_route(route.path, route.handler())

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,23 +1,10 @@
-from collections import namedtuple
-
-from . import handlers
-
-
-Route = namedtuple("Route", ["method", "path", "handler", "name"])
-
-
-ROUTES = [
-    Route("GET",  "/", handler=handlers.get_index,  name="get_index"),
-    Route("POST", "/", handler=handlers.post_index, name="post_index"),
-    Route("GET", "/info", handler=handlers.get_info, name="get_info"),
-]
+from .handlers import routes
 
 
 def setup(app, url_path_prefix):
     """Set up routes."""
     prefix = url_path_prefix.lstrip("/")
-    for route in ROUTES:
-        method, url, handler, name = route
-        url = url.lstrip('/')
-        full_url = f"/{prefix}{url}" if name != "get_info" else f"/{url}"   # Preserve /info for app health check
-        app.router.add_route(method, full_url, handler, name=name)
+    for route in routes:
+        url = route.path.lstrip('/')
+        route_path = f"/{prefix}{url}" if route.kwargs.get('use_prefix', True) else f"/{url}"
+        app.router.add_route(route.method, route_path, route.handler, name=route.kwargs.get('name'))

--- a/app/routes.py
+++ b/app/routes.py
@@ -14,10 +14,10 @@ ROUTES = [
 
 
 def setup(app, url_path_prefix):
-    """Set up routes. Preserve /info for app health check"""
+    """Set up routes."""
     prefix = url_path_prefix.lstrip("/")
     for route in ROUTES:
         method, url, handler, name = route
         url = url.lstrip('/')
-        full_url = f"/{prefix}{url}" if name != "get_info" else f"/{url}"
+        full_url = f"/{prefix}{url}" if name != "get_info" else f"/{url}"   # Preserve /info for app health check
         app.router.add_route(method, full_url, handler, name=name)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -68,7 +68,7 @@
                 </div>
                 <div class="grid__col col-12@m">
                     <div class="footer__license footer__license--border">
-                        <img alt="OGL" class="footer__ogl-img" src="/s/img/ogl.svg"> All content is available under the
+                        <img alt="OGL" class="footer__ogl-img" src="{{ static('/s/img/ogl.svg') }}"> All content is available under the
                         <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" class="footer__link">Open Government
                     Licence v3.0</a>, except where otherwise stated
                     </div>
@@ -85,7 +85,7 @@
 <![endif]-->
 <!-- jQuery 2 -->
 <!--[if gte IE 9]><!-->
-<script src="/js/vendor/jquery-2.2.0.min.js"></script>
+<script src="{{ static('/js/vendor/jquery-2.2.0.min.js') }}"></script>
 <script nonce="{{ request.csp_nonce }}">window.jQuery || document.write('<script "{{ static('/js/vendor/jquery-2.2.0.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee') }}"><\/script>')</script>
 <!--<![endif]-->
 <!--[if gte IE 9]><!-->

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,10 +10,10 @@
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <link rel="shortcut icon" href="favicon.ico">
   <!--[if lt IE 9]>
-    <script src="/js/vendor/html5shiv.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"></script>
+    <script src="{{ static('/js/vendor/html5shiv.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee') }}"></script>
   <![endif]-->
   <!--[if lte IE 9]>
-    <script src="/js/polyfills.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"></script>
+    <script src="{{ static('/js/polyfills.js?q=95ed16e2c89bb26d9c02129271468664828e4cee') }}"></script>
   <![endif]-->
   <!--[if gt IE 8]><!-->
   <script nonce="{{ request.csp_nonce }}">document.documentElement.className = document.documentElement.className.replace('no-js', 'has-js')</script>
@@ -22,7 +22,7 @@
   <link href="{{ static('css/responsive.css') }}" rel="stylesheet">
   <!--<![endif]-->
   <!--[if (lte IE 9) & (!IEMobile)]>
-    <link href="/css/fixed.min.css?q=95ed16e2c89bb26d9c02129271468664828e4cee" rel="stylesheet">
+    <link href="{{ static('/css/fixed.min.css?q=95ed16e2c89bb26d9c02129271468664828e4cee') }}" rel="stylesheet">
   <![endif]-->
 
 
@@ -80,15 +80,15 @@
 <!-- jQuery 1 -->
 <!--[if lt IE 9]>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script "/js/vendor/jquery-1.12.0.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"><\/script>')</script>
+<script>window.jQuery || document.write('<script "{{ static('/js/vendor/jquery-1.12.0.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee') }}"><\/script>')</script>
 <![endif]-->
 <!-- jQuery 2 -->
 <!--[if gte IE 9]><!-->
 <script src="/js/vendor/jquery-2.2.0.min.js"></script>
-<script nonce="{{ request.csp_nonce }}">window.jQuery || document.write('<script "/js/vendor/jquery-2.2.0.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee"><\/script>')</script>
+<script nonce="{{ request.csp_nonce }}">window.jQuery || document.write('<script "{{ static('/js/vendor/jquery-2.2.0.min.js?q=95ed16e2c89bb26d9c02129271468664828e4cee') }}"><\/script>')</script>
 <!--<![endif]-->
 <!--[if gte IE 9]><!-->
-<script src="/js/bundle.js"></script>
+<script src="{{ static('/js/bundle.js') }}"></script>
   <!--<![endif]-->
   <!-- <%= yield_content :javascript %>
     <% unless analytics_account.nil? %>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,7 +7,7 @@
   {% endif %}
   <div>
   <h2 class="saturn u-mt-l u-mb-m">Please enter your 12 character access code</h2>
-    <form action="{{ url('index') }}" class="form qa-questionnaire-form" role="form" method="post" novalidate="">
+    <form action="{{ url('Index:post') }}" class="form qa-questionnaire-form" role="form" method="post" novalidate="">
       <div class="panel panel--simple panel--spacious {% if 'ERROR' in messages_dict %} panel--error {% else %} panel--info {% endif %} u-mb-l">
         <div class="panel__body">
           <div class="group" id="household-and-accommodation">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -39,7 +39,7 @@
 {% endif %}
 <div>
 <h2 class="saturn u-mt-l u-mb-m">Please enter your 12 character access code</h2>
-  <form action="/" class="form qa-questionnaire-form" role="form" method="post" novalidate="">
+  <form action="{{ url('post_index') }}" class="form qa-questionnaire-form" role="form" method="post" novalidate="">
     <div class="panel panel--simple panel--spacious {% if messages %} panel--error {% else %} panel--info {% endif %} u-mb-l">
       <div class="panel__body">
         <div class="group" id="household-and-accommodation">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,7 +7,7 @@
   {% endif %}
   <div>
   <h2 class="saturn u-mt-l u-mb-m">Please enter your 12 character access code</h2>
-    <form action="{{ url('post_index') }}" class="form qa-questionnaire-form" role="form" method="post" novalidate="">
+    <form action="{{ url('index') }}" class="form qa-questionnaire-form" role="form" method="post" novalidate="">
       <div class="panel panel--simple panel--spacious {% if 'ERROR' in messages_dict %} panel--error {% else %} panel--info {% endif %} u-mb-l">
         <div class="panel__body">
           <div class="group" id="household-and-accommodation">

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -6,7 +6,6 @@ import uuid
 from aiohttp.test_utils import AioHTTPTestCase
 
 from app.app import create_app
-from app.eq import build_response_id
 
 
 def skip_build_eq(func, *args, **kwargs):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -193,6 +193,10 @@ class RHTestCase(AioHTTPTestCase):
         with open('tests/test_data/survey/survey.json') as fp:
             self.survey_json = json.load(fp)
 
+        self.get_index = self.app.router._named_resources['get_index'].canonical
+        self.get_info = self.app.router._named_resources['get_info'].canonical
+        self.post_index = self.app.router._named_resources['post_index'].canonical
+
         self.action_plan_id = self.case_json['actionPlanId']
         self.case_id = self.case_json['id']
         self.case_group_id = self.case_json['caseGroup']['id']
@@ -227,7 +231,7 @@ class RHTestCase(AioHTTPTestCase):
             "ru_name": self.ru_name,
             "case_id": self.case_id,
             "case_ref": self.case_ref,
-            "account_service_url": self.app['ACCOUNT_SERVICE_URL'],
+            "account_service_url": f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}",
             "language_code": self.language_code,
             "return_by": self.return_by,
             "ref_p_end_date": self.end_date,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -210,9 +210,9 @@ class RHTestCase(AioHTTPTestCase):
         with open('tests/test_data/survey/survey.json') as fp:
             self.survey_json = json.load(fp)
 
-        self.get_index = self.app.router._named_resources['index'].canonical
-        self.get_info = self.app.router._named_resources['info'].canonical
-        self.post_index = self.app.router._named_resources['index'].canonical
+        self.get_index = self.app.router['Index:get'].url_for()
+        self.get_info = self.app.router['Info:get'].url_for()
+        self.post_index = self.app.router['Index:post'].url_for()
 
         self.action_plan_id = self.case_json['actionPlanId']
         self.case_id = self.case_json['id']

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -210,9 +210,9 @@ class RHTestCase(AioHTTPTestCase):
         with open('tests/test_data/survey/survey.json') as fp:
             self.survey_json = json.load(fp)
 
-        self.get_index = self.app.router._named_resources['get_index'].canonical
-        self.get_info = self.app.router._named_resources['get_info'].canonical
-        self.post_index = self.app.router._named_resources['post_index'].canonical
+        self.get_index = self.app.router._named_resources['index'].canonical
+        self.get_info = self.app.router._named_resources['info'].canonical
+        self.post_index = self.app.router._named_resources['index'].canonical
 
         self.action_plan_id = self.case_json['actionPlanId']
         self.case_id = self.case_json['id']

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -53,6 +53,8 @@ class TestCreateAppURLPathPrefix(TestCase):
         app = create_app(self.config)
         routes = app.router._named_resources
 
+        self.assertEqual(app['URL_PATH_PREFIX'], url_prefix)
+
         for route in routes.values():
             url = route.canonical
             if url == '/info':

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -7,6 +7,7 @@ from aioresponses import aioresponses
 from envparse import ConfigurationError, env
 
 from app.app import create_app
+from app.handlers import routes
 
 
 class TestCreateApp(AioHTTPTestCase):
@@ -51,15 +52,11 @@ class TestCreateAppURLPathPrefix(TestCase):
         config.TestingConfig.URL_PATH_PREFIX = url_prefix
 
         app = create_app(self.config)
-        routes = app.router._named_resources
-
         self.assertEqual(app['URL_PATH_PREFIX'], url_prefix)
 
-        for route in routes.values():
-            url = route.canonical
-            if url == '/info':
-                continue
-            self.assertTrue(url.startswith(url_prefix), msg=f"{url} not prefixed with {url_prefix}")
+        routes = app.router._named_resources
+        self.assertEqual(routes['index'].canonical, url_prefix)
+        self.assertEqual(routes['info'].canonical, '/info')
 
 
 class TestCreateAppMissingConfig(TestCase):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -39,6 +39,18 @@ class TestCreateApp(AioHTTPTestCase):
         self.assertEqual(response.headers['X-Content-Type-Options'], 'nosniff')
         self.assertEqual(response.headers['Referrer-Policy'], 'same-origin')
 
+    def test_create_app_with_url_path_prefix(self):
+        from app import config
+
+        url_prefix = '/url-path-prefix'
+        config.TestingConfig.URL_PATH_PREFIX = url_prefix
+
+        app = create_app(self.config)
+        routes = app.router._named_resources
+
+        for route in routes.values():
+            self.assertTrue(route.canonical.startswith(url_prefix))
+
 
 class TestCreateAppMissingConfig(TestCase):
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -39,6 +39,11 @@ class TestCreateApp(AioHTTPTestCase):
         self.assertEqual(response.headers['X-Content-Type-Options'], 'nosniff')
         self.assertEqual(response.headers['Referrer-Policy'], 'same-origin')
 
+
+class TestCreateAppURLPathPrefix(TestCase):
+
+    config = 'TestingConfig'
+
     def test_create_app_with_url_path_prefix(self):
         from app import config
 
@@ -49,7 +54,10 @@ class TestCreateApp(AioHTTPTestCase):
         routes = app.router._named_resources
 
         for route in routes.values():
-            self.assertTrue(route.canonical.startswith(url_prefix))
+            url = route.canonical
+            if url == '/info':
+                continue
+            self.assertTrue(url.startswith(url_prefix), msg=f"{url} not prefixed with {url_prefix}")
 
 
 class TestCreateAppMissingConfig(TestCase):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -58,6 +58,18 @@ class TestCreateAppURLPathPrefix(TestCase):
         self.assertEqual(routes['index'].canonical, url_prefix)
         self.assertEqual(routes['info'].canonical, '/info')
 
+    def test_create_app_without_url_path_prefix(self):
+        from app import config
+
+        config.TestingConfig.URL_PATH_PREFIX = ''
+
+        app = create_app(self.config)
+        self.assertEqual(app['URL_PATH_PREFIX'], '')
+
+        routes = app.router._named_resources
+        self.assertEqual(routes['index'].canonical, '')
+        self.assertEqual(routes['info'].canonical, '/info')
+
 
 class TestCreateAppMissingConfig(TestCase):
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -53,9 +53,9 @@ class TestCreateAppURLPathPrefix(TestCase):
         app = create_app(self.config)
         self.assertEqual(app['URL_PATH_PREFIX'], url_prefix)
 
-        routes = app.router._named_resources
-        self.assertEqual(routes['index'].canonical, url_prefix)
-        self.assertEqual(routes['info'].canonical, '/info')
+        self.assertEqual(app.router['Index:get'].canonical, '/url-path-prefix/')
+        self.assertEqual(app.router['Index:post'].canonical, '/url-path-prefix/')
+        self.assertEqual(app.router['Info:get'].canonical, '/info')
 
     def test_create_app_without_url_path_prefix(self):
         from app import config
@@ -65,9 +65,9 @@ class TestCreateAppURLPathPrefix(TestCase):
         app = create_app(self.config)
         self.assertEqual(app['URL_PATH_PREFIX'], '')
 
-        routes = app.router._named_resources
-        self.assertEqual(routes['index'].canonical, '')
-        self.assertEqual(routes['info'].canonical, '/info')
+        self.assertEqual(app.router['Index:get'].canonical, '/')
+        self.assertEqual(app.router['Index:post'].canonical, '/')
+        self.assertEqual(app.router['Info:get'].canonical, '/info')
 
 
 class TestCreateAppMissingConfig(TestCase):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -7,7 +7,6 @@ from aioresponses import aioresponses
 from envparse import ConfigurationError, env
 
 from app.app import create_app
-from app.handlers import routes
 
 
 class TestCreateApp(AioHTTPTestCase):

--- a/tests/unit/test_error_handlers.py
+++ b/tests/unit/test_error_handlers.py
@@ -1,0 +1,27 @@
+from aiohttp.test_utils import unittest_run_loop
+
+from app.app import create_app
+from . import RHTestCase
+
+
+class TestErrorHandlers(RHTestCase):
+
+    config = 'TestingConfig'
+
+    async def get_application(self):
+        from app import config
+
+        url_prefix = '/url-path-prefix'
+        config.TestingConfig.URL_PATH_PREFIX = url_prefix
+        return create_app(self.config)
+
+    @unittest_run_loop
+    async def test_partial_path_redirects_to_index(self):
+        with self.assertLogs('respondent-home', 'DEBUG') as cm:
+            response = await self.client.request("GET", str(self.get_index).rstrip('/'))
+        self.assertLogLine(cm, 'Redirecting to root')
+        self.assertEqual(response.status, 200)
+        contents = await response.content.read()
+        self.assertIn(b'Your access code is printed on the letter we sent you', contents)
+        self.assertEqual(contents.count(b'input-text'), 3)
+        self.assertIn(b'type="submit"', contents)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -10,7 +10,7 @@ from app import (
     BAD_CODE_MSG, BAD_RESPONSE_MSG, CODE_USED_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG,
     CONNECTION_ERROR_MSG, REDIRECT_FAILED_MSG, SERVER_ERROR_MSG)
 from app.exceptions import InactiveCaseError
-from app.handlers import join_iac, validate_case
+from app.handlers import Index
 
 from . import RHTestCase, build_eq_raises, skip_build_eq, skip_encrypt
 
@@ -460,7 +460,7 @@ class TestHandlers(RHTestCase):
         post_data = {'iac1': '1234', 'iac2': '5678', 'iac3': '9012', 'action[save_continue]': ''}
 
         # When join_iac is called
-        result = join_iac(post_data)
+        result = Index.join_iac(post_data)
 
         # Then a single string built from the iac values is returned
         self.assertEqual(result, post_data['iac1'] + post_data['iac2'] + post_data['iac3'])
@@ -471,7 +471,7 @@ class TestHandlers(RHTestCase):
 
         # When join_iac is called
         with self.assertRaises(TypeError):
-            join_iac(post_data)
+            Index.join_iac(post_data)
         # Then a TypeError is raised
 
     def test_join_iac_some_missing(self):
@@ -480,7 +480,7 @@ class TestHandlers(RHTestCase):
 
         # When join_iac is called
         with self.assertRaises(TypeError):
-            join_iac(post_data)
+            Index.join_iac(post_data)
         # Then a TypeError is raised
 
     def test_validate_case(self):
@@ -488,7 +488,7 @@ class TestHandlers(RHTestCase):
         case_json = {'active': True}
 
         # When validate_case is called
-        validate_case(case_json)
+        Index.validate_case(case_json)
 
         # Nothing happens
 
@@ -498,7 +498,7 @@ class TestHandlers(RHTestCase):
 
         # When validate_case is called
         with self.assertRaises(InactiveCaseError):
-            validate_case(case_json)
+            Index.validate_case(case_json)
 
         # Then an InactiveCaseError is raised
 
@@ -508,6 +508,6 @@ class TestHandlers(RHTestCase):
 
         # When validate_case is called
         with self.assertRaises(InactiveCaseError):
-            validate_case(case_json)
+            Index.validate_case(case_json)
 
         # Then an InactiveCaseError is raised

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -19,7 +19,7 @@ class TestHandlers(RHTestCase):
 
     @unittest_run_loop
     async def test_get_index(self):
-        response = await self.client.request("GET", "/")
+        response = await self.client.request("GET", self.get_index)
         self.assertEqual(response.status, 200)
         contents = await response.content.read()
         self.assertIn(b'Your access code is printed on the letter we sent you', contents)
@@ -35,7 +35,7 @@ class TestHandlers(RHTestCase):
             mocked.post(self.case_events_url)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, 'Redirecting to eQ')
 
         self.assertEqual(response.status, 302)
@@ -47,7 +47,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, exception=ClientConnectorError(mock.MagicMock(), mock.MagicMock()))
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Service connection error")
 
         self.assertEqual(response.status, 200)
@@ -59,7 +59,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, content_type='text')
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Service failed to return expected JSON payload")
 
         self.assertEqual(response.status, 200)
@@ -72,7 +72,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.case_url, status=403)
 
             with self.assertLogs('app.case', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Error retrieving case", case_id=self.case_id, status_code=403)
 
         self.assertEqual(response.status, 200)
@@ -85,7 +85,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.case_url, status=500)
 
             with self.assertLogs('app.case', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Error retrieving case", case_id=self.case_id, status_code=500)
 
         self.assertEqual(response.status, 200)
@@ -98,7 +98,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.case_url, exception=ClientConnectorError(mock.MagicMock(), mock.MagicMock()))
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Service connection error")
 
         self.assertEqual(response.status, 200)
@@ -112,7 +112,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.collection_instrument_url, exception=ClientConnectionError('Failed'))
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Service connection error", message='Failed')
 
         self.assertEqual(response.status, 200)
@@ -134,7 +134,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.survey_url, payload=self.survey_json)
 
             with self.assertLogs('respondent-home', 'INFO') as logs_home, self.assertLogs('app.eq', 'INFO') as logs_eq:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(logs_home, 'Redirecting to eQ')
 
         self.assertEqual(response.status, 302)
@@ -160,7 +160,7 @@ class TestHandlers(RHTestCase):
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
                 # decorator makes URL constructor raise InvalidEqPayLoad when build() is called in handler
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Service failed to build eQ payload")
 
         # then error handler catches exception and flashes message to index
@@ -178,7 +178,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.collection_instrument_url, status=500)
 
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Error in response", status_code=500)
 
         self.assertEqual(response.status, 200)
@@ -195,7 +195,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.collection_instrument_url, status=400)
 
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Error in response", status_code=400)
 
         self.assertEqual(response.status, 200)
@@ -213,7 +213,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.collection_exercise_url, status=503)
 
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Error in response", status_code=503)
 
         self.assertEqual(response.status, 200)
@@ -232,7 +232,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.collection_exercise_events_url, status=404)
 
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Error in response", status_code=404)
 
         self.assertEqual(response.status, 200)
@@ -252,7 +252,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.sample_attributes_url, status=403)
 
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Error in response", status_code=403)
 
         self.assertEqual(response.status, 200)
@@ -273,7 +273,7 @@ class TestHandlers(RHTestCase):
             mocked.post(self.case_events_url, status=500)
 
             with self.assertLogs('app.case', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, "Error posting case event", status_code=500, case_id=self.case_id)
 
         self.assertEqual(response.status, 200)
@@ -288,7 +288,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, payload=iac_json)
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, 'caseId missing from IAC response')
 
         self.assertEqual(response.status, 200)
@@ -304,7 +304,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.case_url, payload=case_json)
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, 'sampleUnitType missing from case response')
 
         self.assertEqual(response.status, 200)
@@ -320,7 +320,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.case_url, payload=case_json)
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, 'Attempt to use unexpected sample unit type', sample_unit_type='B')
 
         self.assertEqual(response.status, 200)
@@ -335,7 +335,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, payload=self.iac_json)
 
             with self.assertLogs('respondent-home', 'WARNING') as cm:
-                response = await self.client.request("POST", "/", data=form_data)
+                response = await self.client.request("POST", self.post_index, data=form_data)
             self.assertLogLine(cm, "Attempt to use a malformed access code")
 
         self.assertEqual(response.status, 200)
@@ -350,7 +350,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, payload=iac_json)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Attempt to use an inactive access code")
 
         self.assertEqual(response.status, 200)
@@ -365,7 +365,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, payload=iac_json)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Attempt to use an inactive access code")
 
         self.assertEqual(response.status, 200)
@@ -377,7 +377,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, exception=ClientConnectionError('Failed'))
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Client failed to connect to iac service")
 
         self.assertEqual(response.status, 200)
@@ -389,7 +389,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, status=500)
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Error in response", status_code=500)
 
         self.assertEqual(response.status, 200)
@@ -401,7 +401,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, status=503)
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Error in response", status_code=503)
 
         self.assertEqual(response.status, 200)
@@ -413,7 +413,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, status=404)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Attempt to use an invalid access code", client_ip=None)
 
         self.assertEqual(response.status, 202)
@@ -425,7 +425,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, status=403)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Unauthorized access to IAC service attempted", client_ip=None)
 
         self.assertEqual(response.status, 200)
@@ -437,7 +437,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, status=401)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Unauthorized access to IAC service attempted", client_ip=None)
 
         self.assertEqual(response.status, 200)
@@ -449,7 +449,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, status=400)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", "/", data=self.form_data)
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Client error when accessing IAC service", client_ip=None, status=400)
 
         self.assertEqual(response.status, 200)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The application needs to handle an optional URL path component prefix which can be configured when deployed. The `/info` route is needed for health-checks, so do not prefix anything for this route. We were unable to configure the manifest to accept variable substitution with Concourse when the app is deployed, so we explicitly ignore this via the code.

The [pipeline changes](https://github.com/ONSdigital/ras-deploy/compare/add-url-path-prefix-for-rh?expand=1) are in place ready for this PR.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Changed app creation behaviour to allow URL prefix when app routes are mapped.
* Ignore URL prefixing for `/info` for health-checks. 

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
1. Edit your `.env` file and set `URL_PATH_PREFIX=/test-prefix`
2. Open Respondent Home UI with the prefix, e.g. `localhost:9092/test-prefix`
3. Ensure the page renders correctly with GETs and POSTs.
4. Repeat above steps but remove `URL_PATH_PREFIX` and ensure page renders at root level with GETs and POSTs.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/vteevzP4/219-sus012-ext-setup-url)