### PR TITLE
Add pip workaround for pipenv

### DIFF
--- a/ci/smoke_tests.sh
+++ b/ci/smoke_tests.sh
@@ -6,5 +6,7 @@ cd respondent-home-ui-source
 # Install libssl-dev for python cryptography lib
 apt-get install libssl-dev -y
 apt-get install python3-dev -y
+pip install --upgrade pip==18.0
+pipenv run pip install --upgrade pip==18.0
 pipenv install --dev
 pipenv run inv smoke


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The smoke tests in the concourse-latest space failed due to the current issue with [pipenv and the use of pip v18.1](https://github.com/pypa/pipenv/issues/2924). 

For the workaround, pin the pip version to the previous working version 18.0 for the smoke test script.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Locked the pip version to 18.0 for the smoke tests.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Ensure the integration tests still pass locally.

The changes have already been flown to the pipeline. This is just to keep the pipeline source up to date.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
N / A