### PR TITLE
Remove ru_name from eq payload

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -169,11 +169,6 @@ class EqPayloadConstructor(object):
             raise InvalidEqPayLoad(f"Could not retrieve attributes for case {self._case_id}")
 
         try:
-            self._ru_name = self._sample_attributes["ADDRESS_LINE1"]
-        except KeyError:
-            raise InvalidEqPayLoad(f"Could not retrieve ru_name (address) for case {self._case_id}")
-
-        try:
             self._country_code = self._sample_attributes["COUNTRY"]
         except KeyError:
             raise InvalidEqPayLoad(f"Could not retrieve country_code for case {self._case_id}")
@@ -194,7 +189,6 @@ class EqPayloadConstructor(object):
             "form_type": self._form_type,  # required but only one ('1') formtype for lms
             "collection_exercise_sid": self._collex_id,  # required by eQ
             "ru_ref": self._sample_unit_ref,  # required by eQ
-            "ru_name": self._ru_name,  # required by eQ - household identifier (address)
             "case_id": self._case_id,  # not required by eQ but useful for downstream
             "case_ref": self._case_ref,  # not required by eQ but useful for downstream
             "account_service_url": self._account_service_url,  # required for save/continue

--- a/app/eq.py
+++ b/app/eq.py
@@ -186,7 +186,7 @@ class EqPayloadConstructor(object):
             "exp": int(time.time() + (5 * 60)),  # required by eQ for creating a new claim
             "eq_id": self._eq_id,  # required but currently only one social survey ('lms')
             "period_id": self._collex_period_id,  # required by eQ
-            "form_type": self._form_type,  # required but only one ('1') formtype for lms
+            "form_type": self._form_type,  # required formtype for lms ('2' for lms_2 schema)
             "collection_exercise_sid": self._collex_id,  # required by eQ
             "ru_ref": self._sample_unit_ref,  # required by eQ
             "case_id": self._case_id,  # not required by eQ but useful for downstream

--- a/app/eq.py
+++ b/app/eq.py
@@ -186,7 +186,7 @@ class EqPayloadConstructor(object):
             "exp": int(time.time() + (5 * 60)),  # required by eQ for creating a new claim
             "eq_id": self._eq_id,  # required but currently only one social survey ('lms')
             "period_id": self._collex_period_id,  # required by eQ
-            "form_type": self._form_type,  # required formtype for lms ('2' for lms_2 schema)
+            "form_type": self._form_type,  # required by eQ ('2' for lms_2 schema)
             "collection_exercise_sid": self._collex_id,  # required by eQ
             "ru_ref": self._sample_unit_ref,  # required by eQ
             "case_id": self._case_id,  # not required by eQ but useful for downstream

--- a/tests/demo/demo.py
+++ b/tests/demo/demo.py
@@ -46,7 +46,6 @@ class DemoRunner:
         self.iac_code = ''.join([str(n) for n in range(11)])
         self.iac1, self.iac2, self.iac3 = self.iac_code[:4], self.iac_code[4:8], self.iac_code[8:]
         self.iac_json = {'active': '1', 'caseId': self.case_id}
-        self.ru_name = self.sample_attributes_json['attributes']['ADDRESS_LINE1']
         self.sample_unit_id = self.sample_attributes_json['id']
         self.sample_unit_ref = self.case_json['caseGroup']['sampleUnitRef']
         self.sample_unit_type = self.case_json['sampleUnitType']
@@ -63,7 +62,6 @@ class DemoRunner:
             "form_type": self.form_type,
             "collection_exercise_sid": self.collection_exercise_id,
             "ru_ref": self.sample_unit_ref,
-            "ru_name": self.ru_name,
             "case_id": self.case_id,
             "case_ref": self.case_ref,
             "account_service_url": self.app['ACCOUNT_SERVICE_URL'],

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -139,8 +139,8 @@ class TestRespondentHome(AioHTTPTestCase):
         location = response.headers['location']
         self.assertIn(self.app['EQ_URL'], location)  # Check that the redirect location is to eQ
         response = requests.get(location)  # Follow the redirect location to check contents
-        address = self.get_address_by_sample_unit_id(sample_unit_id).encode()
-        self.assertIn(address, response.content)  # Use the household address as a simple point of verification
+        self.assertIn(b'What is your name', response.content)
+        self.assertIn(b'Online Household Study', response.content)
         case_response = await get_case(case['id'], self.app)
         case_state = case_response['caseGroup']['caseGroupStatus']
         self.assertEqual(case_state, 'NOTSTARTED')  # Ensure the case status has not transitioned

--- a/tests/test_data/collection_instrument/collection_instrument_eq.json
+++ b/tests/test_data/collection_instrument/collection_instrument_eq.json
@@ -2,7 +2,7 @@
   "businesses": [],
   "classifiers": {
     "eq_id": "lms",
-    "form_type": "1"
+    "form_type": "2"
   },
   "exercises": [],
   "file_name": "EQ-File",

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -228,7 +228,6 @@ class RHTestCase(AioHTTPTestCase):
         self.iac_code = ''.join([str(n) for n in range(11)])
         self.iac1, self.iac2, self.iac3 = self.iac_code[:4], self.iac_code[4:8], self.iac_code[8:]
         self.iac_json = {'active': '1', 'caseId': self.case_id}
-        self.ru_name = self.sample_attributes_json['attributes']['ADDRESS_LINE1']
         self.sample_unit_id = self.sample_attributes_json['id']
         self.sample_unit_ref = self.case_json['caseGroup']['sampleUnitRef']
         self.sample_unit_type = self.case_json['sampleUnitType']
@@ -245,7 +244,6 @@ class RHTestCase(AioHTTPTestCase):
             "form_type": self.form_type,
             "collection_exercise_sid": self.collection_exercise_id,
             "ru_ref": self.sample_unit_ref,
-            "ru_name": self.ru_name,
             "case_id": self.case_id,
             "case_ref": self.case_ref,
             "account_service_url": f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}",

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -212,23 +212,6 @@ class TestEq(RHTestCase):
             self.assertIn(f"Could not retrieve ce id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
-    async def test_build_raises_InvalidEqPayLoad_missing_name(self):
-        sample_json = self.sample_attributes_json.copy()
-        del sample_json['attributes']['ADDRESS_LINE1']
-
-        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
-
-        with aioresponses() as mocked:
-            mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
-            mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
-            mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
-            mocked.get(self.sample_attributes_url, payload=sample_json)
-
-            with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
-            self.assertIn(f"Could not retrieve ru_name (address) for case {self.case_id}", ex.exception.message)
-
-    @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_country_code(self):
         sample_json = self.sample_attributes_json.copy()
         del sample_json['attributes']['COUNTRY']


### PR DESCRIPTION
# Motivation and Context
The `ru_name` is not a relevant field for social surveys and has been removed from the EQ LMS schema.

# What has changed
* removed ru_name from eq payload
* removed test for ru_name
* removed ru_name from test data

# How to test?
All functionality should remain the same, just the payload no longer contains `ru_name`

To run the integration tests locally you'll need changes on this branch of rm-tools: https://github.com/ONSdigital/rm-tools/pull/28
Modify the data_setup.sh script to point to that branch like this:
```shell
git clone --depth 1 ${rm_tools_repo_url} --single-branch -b update-social-eq-form-type tmp_rm_tools;
```
Then the integration tests should pass

# Links
https://trello.com/c/QwnRHhx2/291-defect-respondent-home-ui-tries-to-use-addressline1-as-runame
https://github.com/ONSdigital/rm-tools/pull/28