### PR TITLE
Update smoke test assertion

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -73,6 +73,7 @@ def smoke(ctx, local=False):
 
     if local:
         os.environ['RESPONDENT_HOME_URL'] = "http://localhost:9092"
+        os.environ['RESPONDENT_HOME_INTERNAL_URL'] = "http://localhost:9092"
     retcode = pytest.main(["tests/smoke"])
     sys.exit(retcode)
 

--- a/tests/smoke/test_respondent_home.py
+++ b/tests/smoke/test_respondent_home.py
@@ -12,9 +12,7 @@ class TestRespondentHome(unittest.TestCase):
         if not respondent_home_url:
             self.fail('RESPONDENT_HOME_URL not set')
 
-        url_prefix = os.getenv('URL_PATH_PREFIX')
-        if not url_prefix:
-            self.fail('URL_PATH_PREFIX not set')
+        url_prefix = os.getenv('URL_PATH_PREFIX', '')
 
         url = f'{respondent_home_url}{url_prefix}'
 

--- a/tests/smoke/test_respondent_home.py
+++ b/tests/smoke/test_respondent_home.py
@@ -13,6 +13,8 @@ class TestRespondentHome(unittest.TestCase):
             self.fail('RESPONDENT_HOME_URL not set')
 
         url_prefix = os.getenv('URL_PATH_PREFIX')
+        if not url_prefix:
+            self.fail('URL_PATH_PREFIX not set')
 
         url = f'{respondent_home_url}{url_prefix}'
 

--- a/tests/smoke/test_respondent_home.py
+++ b/tests/smoke/test_respondent_home.py
@@ -20,8 +20,7 @@ class TestRespondentHome(unittest.TestCase):
         resp = requests.get(url, verify=False)
 
         # Then
-        message = f'URL: {url}, status_code: {resp.status_code}'
-        self.assertEqual(resp.status_code, 200, message)
+        self.assertEqual(resp.status_code, 200, url)
 
     def test_can_access_required_services(self):
         # Given

--- a/tests/smoke/test_respondent_home.py
+++ b/tests/smoke/test_respondent_home.py
@@ -16,7 +16,8 @@ class TestRespondentHome(unittest.TestCase):
         resp = requests.get(url, verify=False)
 
         # Then
-        self.assertEqual(resp.status_code, 200, resp.status_code)
+        message = f'URL: {url}, status_code: {resp.status_code}'
+        self.assertEqual(resp.status_code, 200, message)
 
     def test_can_access_required_services(self):
         # Given
@@ -29,3 +30,4 @@ class TestRespondentHome(unittest.TestCase):
 
         # Then
         self.assertEqual(resp['ready'], True, resp)
+        self.assertEqual(resp['name'], "respondent-home-ui", resp)

--- a/tests/smoke/test_respondent_home.py
+++ b/tests/smoke/test_respondent_home.py
@@ -8,9 +8,13 @@ class TestRespondentHome(unittest.TestCase):
 
     def test_can_access_respondent_home_homepage(self):
         # Given
-        url = os.getenv('RESPONDENT_HOME_URL')
-        if not url:
+        respondent_home_url = os.getenv('RESPONDENT_HOME_URL')
+        if not respondent_home_url:
             self.fail('RESPONDENT_HOME_URL not set')
+
+        url_prefix = os.getenv('URL_PATH_PREFIX')
+
+        url = f'{respondent_home_url}{url_prefix}'
 
         # When
         resp = requests.get(url, verify=False)

--- a/tests/smoke/test_respondent_home.py
+++ b/tests/smoke/test_respondent_home.py
@@ -24,9 +24,9 @@ class TestRespondentHome(unittest.TestCase):
 
     def test_can_access_required_services(self):
         # Given
-        url = os.getenv('RESPONDENT_HOME_URL')
+        url = os.getenv('RESPONDENT_HOME_INTERNAL_URL')
         if not url:
-            self.fail('RESPONDENT_HOME_URL not set')
+            self.fail('RESPONDENT_HOME_INTERNAL_URL not set')
 
         # When
         resp = requests.get(f'{url}/info?check=true', verify=False).json()


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now that this app can be configured to handle a URL path prefix, we need to ensure that when smoke tests are run, the app is configured as we expected.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated smoke test to ensure `URL_PATH_PREFIX` is used. This will default to an empty string if not set. This variable is set by the pipeline before a smoke test is run. 

Dependent on [this PR](https://github.com/ONSdigital/ras-deploy/pull/86)

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* Set `URL_PATH_PREFIX=/testpathprefix`
* `make run`
* In a separate command line `pipenv run inv smoke --local` 

Repeat above, and ensure `URL_PATH_PREFIX` is unset.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/vteevzP4/219-sus012-ext-setup-url)