### PR TITLE
Sus021 privacy page update

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -156,3 +156,10 @@ class Index:
 
         logger.info('Redirecting to eQ', client_ip=self.client_ip)
         raise HTTPFound(f"{self.request.app['EQ_URL']}/session?token={token}")
+
+
+@routes.view('/cookies-privacy')
+class CookiesPrivacy:
+    @aiohttp_jinja2.template('cookies-privacy.html')
+    async def get(self, _):
+        return {}

--- a/app/templates/cookies-privacy.html
+++ b/app/templates/cookies-privacy.html
@@ -1,437 +1,358 @@
+{% extends "base.html" %}
 
-{% block page_title %}Cookies and privacy - ONS Business Surveys{% endblock %}
+{% block title %}Cookies and privacy - My Study{% endblock title %}
 
-{% block main %}
+{% block content %}
 
-                <h1 class="saturn">
-                    Cookies and Privacy
-                </h1>
+<h1 class="saturn">
+    Cookies and Privacy
+</h1>
 
-                <p>The Office for National Statistics (ONS) has created this cookies and privacy
-                    statement in order to demonstrate our firm commitment to privacy.</p>
+<p>The Office for National Statistics (ONS) has created this cookies and privacy
+    statement in order to demonstrate our firm commitment to privacy.</p>
 
-                <p>The following is a description of what data is collected when you use this service,
-                    how it is stored and what it is used for.</p>
+<p>The following is a description of what data is collected when you use this service,
+    how it is stored and what it is used for.</p>
 
-                <div>
-                    <h2 class="neptune u-mt-l">
-                        Privacy
-                    </h2>
+<div>
+    <h2 class="neptune u-mt-l">
+        Privacy
+    </h2>
 
-                    <div>
-                        <p>Your privacy is very important to us. We comply with confidentiality
-                            requirements set out in the Statistics and Registration Service Act 2007 and
-                            the Data Protection Act 1998.</p>
+    <div>
+        <p>Your privacy is very important to us. We comply with confidentiality
+            requirements set out in the Statistics and Registration Service Act 2007 and
+            the Data Protection Act 1998.</p>
 
-                        <p>We can only use your information for research and statistical purposes. None
-                            of your personal information is disclosed through our statistics.</p>
+        <p>We can only use your information for research and statistical purposes. None
+            of your personal information is disclosed through our statistics.</p>
 
-                    </div>
-
-                    <h2 class="neptune u-mt-l">
-                        Security
-                    </h2>
-
-                    <div>
-                        <p>We ensure that the information you provide is kept safe and secure. We have
-                            security measures in place to protect the loss, misuse and alteration of
-                            information under our control.</p>
+    </div>
+
+    <h2 class="neptune u-mt-l">
+        Security
+    </h2>
+
+    <div>
+        <p>We ensure that the information you provide is kept safe and secure. We have
+            security measures in place to protect the loss, misuse and alteration of
+            information under our control.</p>
+
+        <p>We use leading security technologies such as industry-standard encryption
+            software. This service has been accredited in accordance with government
+            technical and security standards.</p>
+    </div>
 
-                        <p>We use leading security technologies such as industry-standard encryption
-                            software. This service has been accredited in accordance with government
-                            technical and security standards.</p>
-                    </div>
+    <h2 class="neptune u-mt-l">
+        Cookies
+    </h2>
 
-                    <h2 class="neptune u-mt-l">
-                        Cookies
-                    </h2>
+    <div>
+        <p>We use small files (known as ‘cookies’) to collect information about how you
+            browse the site.</p>
 
-                    <div>
-                        <p>We use small files (known as ‘cookies’) to collect information about how you
-                            browse the site.</p>
+        <p>Cookies are used to:</p>
+
+        <ul>
+            <li>Measure how you use the website so it can be updated and improved based
+                on your needs
+            </li>
+            <li>Remember the notifications you’ve seen so that we don’t show them to you
+                again
+            </li>
+        </ul>
+
+        <p><strong>Our cookies are not used to identify you personally.</strong></p>
+    </div>
+
+    <h2 class="neptune u-mt-l">
+        How cookies are used
+    </h2>
+
+    <div>
+        <p><strong>Measuring website usage (Google Analytics)</strong></p>
+
+        <p>We use Google Analytics software to collect information about how you use
+            this service. We do this to help make sure the site is meeting the needs of
+            its users and to help us make improvements, for example improving site
+            search.</p>
+
+        <p>Google Analytics stores information about:</p>
+
+        <ul>
+            <li>The pages you visit</li>
+            <li>How long you spend on each page</li>
+            <li>How you got to the site</li>
+            <li>What you click on while you’re visiting the site</li>
+        </ul>
+
+        <p>We don’t use Google Analytics to collect or store your personal information
+            (for example your name or address).</p>
+
+        <p>The information we collect through our cookies does not include personal
+            details such as your name, age, telephone number, postal address or email
+            address, nor does it allow personal identification of a user.</p>
+
+        <p>You can manage these small files yourself and learn more about them through
+            <a href="https://www.aboutcookies.org/">internet browser cookies – what they
+                are and how to manage them.</a></p>
+
+    </div>
+
 
-                        <p>Cookies are used to:</p>
-
-                        <ul>
-                            <li>Measure how you use the website so it can be updated and improved based
-                                on your needs
-                            </li>
-                            <li>Remember the notifications you’ve seen so that we don’t show them to you
-                                again
-                            </li>
-                        </ul>
-
-                        <p><strong>Our cookies are not used to identify you personally.</strong></p>
-                    </div>
 
-                    <h2 class="neptune u-mt-l">
-                        How cookies are used
-                    </h2>
 
-                    <div>
-                        <p><strong>Measuring website usage (Google Analytics)</strong></p>
-
-                        <p>We use Google Analytics software to collect information about how you use
-                            this service. We do this to help make sure the site is meeting the needs of
-                            its users and to help us make improvements, for example improving site
-                            search.</p>
-
-                        <p>Google Analytics stores information about:</p>
-
-                        <ul>
-                            <li>The pages you visit</li>
-                            <li>How long you spend on each page</li>
-                            <li>How you got to the site</li>
-                            <li>What you click on while you’re visiting the site</li>
-                        </ul>
-
-                        <p>We don’t use Google Analytics to collect or store your personal information
-                            (for example your name or address).</p>
-
-                        <p>The information we collect through our cookies does not include personal
-                            details such as your name, age, telephone number, postal address or email
-                            address, nor does it allow personal identification of a user.</p>
-
-                        <p>You can manage these small files yourself and learn more about them through
-                            <a href="https://www.aboutcookies.org/">internet browser cookies – what they
-                                are and how to manage them.</a></p>
-
-                    </div>
-
-
-
-
-                    <h2 class="neptune u-mt-l">
-                        Universal Analytics
-                    </h2>
-
-
-                    <table class="table">
-                      <thead class="table__head table__header-cell--align">
-                        <tr>
-                          <th class="table__header-cell table__header-cell--align">Name</th>
-                          <th class="table__header-cell">Purpose</th>
-                          <th class="table__header-cell">Expires</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr class="table__row">
-                          <td class="table__cell">_ga</td>
-                          <td class="table__cell">This helps us count how many people visit our website by tracking if you’ve visited before</td>
-                          <td class="table__cell nowrap">2 years</td>
-                        </tr>
-                        <tr class="table__row">
-                          <td class="table__cell">_gid</td>
-                          <td class="table__cell">This helps us count how many people visit our website by tracking if you’ve visited before</td>
-                          <td class="table__cell nowrap">24 hours</td>
-                        </tr>
-                        <tr class="table__row">
-                          <td class="table__cell">_gat</td>
-                          <td class="table__cell">Used to manage the rate at which page view requests are made</td>
-                          <td class="table__cell nowrap">10 minutes</td>
-                        </tr>
-                      </tbody>
-                    </table>
-
-
-
-
-                    <h2 class="neptune u-mt-l">
-                        Completing a survey (eq.ons.gov.uk)
-                    </h2>
-
-
-                    <table class="table">
-                        <thead class="table__head">
-                        <tr>
-                            <th class="table__header-cell">Name</th>
-                            <th class="table__header-cell">Purpose</th>
-                            <th class="table__header-cell">Expires</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <tr class="table__row">
-                            <td class="table__cell">Session</td>
-                            <td class="table__cell">To keep you signed in when completing a survey</td>
-                            <td class="table__cell">When a user logs out or closes the browser. Or when
-                                their cookie cache is cleared
-                            </td>
-                        </tr>
-                        </tbody>
-                    </table>
-
-
-
-
-                    <h2 class="neptune u-mt-l">
-                        Your account (surveys.ons.gov.uk)
-                    </h2>
-
-
-                    <table class="table">
-                        <thead class="table__head">
-                        <tr>
-                            <th class="table__header-cell">Name</th>
-                            <th class="table__header-cell">Purpose</th>
-                            <th class="table__header-cell">Expires</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <tr>
-                            <td class="table__cell">COOKIE_SUPPORT</td>
-                            <td class="table__cell">To check that your browser can support cookies</td>
-                            <td class="table__cell">When a user closes the browser or when their cookie
-                                cache is cleared
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="table__cell">GUEST_LANGUAGE_ID</td>
-                            <td class="table__cell">To store your preferred language so that certain
-                                content can be displayed in your own language
-                            </td>
-                            <td class="table__cell">When a user closes the browser or when their cookie
-                                cache is cleared
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="table__cell">JSESSIONID</td>
-                            <td class="table__cell">To keep your session active when using your account
-                                to access portfolio and messages
-                            </td>
-                            <td class="table__cell">When a user closes the browser or when their cookie
-                                cache is cleared
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="table__cell">ID</td>
-                            <td class="table__cell">To store an encrypted identifier which is used to
-                                retrieve the information associated to your account
-                            </td>
-                            <td class="table__cell">When a user logs out or closes the browser or when
-                                their cookie cache is cleared
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="table__cell">COMPANY_ID</td>
-                            <td class="table__cell">To store an identifier which is used to retrieve the
-                                permissions associated to your account
-                            </td>
-                            <td class="table__cell">When a user logs out or closes the browser or when
-                                their cookie cache is cleared
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="table__cell">USER_UUID</td>
-                            <td class="table__cell">To store the universally unique identifier created
-                                for your account
-                            </td>
-                            <td class="table__cell">When a user closes the browser or when their cookie
-                                cache is cleared
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="table__cell">LFR_SESSION_STATE_*</td>
-                            <td class="table__cell">To store the timestamp of the last request so that
-                                the session expiry warning message can be displayed
-                            </td>
-                            <td class="table__cell">When a user closes the browser or when their cookie
-                                cache is cleared
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="table__cell">csfcfc</td>
-                            <td class="table__cell">To store the flash object identifier for the most
-                                recent action you have performed
-                            </td>
-                            <td class="table__cell">When a user closes the browser or when their cookie
-                                cache is cleared
-                            </td>
-                        </tr>
-                        </tbody>
-                    </table>
-
-
-
-
-                    <h2 class="neptune u-mt-l">
-                        Data controller
-                    </h2>
-
-                    <p>The Data Controller for ONS Surveys is:</p><p>Office for National Statistics<br>Government Buildings<br>Cardiff Road<br>Newport<br>South Wales<br>NP10 8XG</p>
-                    <p>For questions regarding the Survey Data Collection service please contact us on:</p>
-                    <p>Telephone: <a href="tel:03001234931">0300 1234 931</a></p>
-
-
-                    <h2 class="neptune u-mt-l">
-                        Why we collect your data
-                    </h2>
-
-                    <p>The Survey Data Collection service is used as the online collection mechanism for a number of our surveys. More surveys will be offered via this service over time.</p>
-                    <p>Individual survey teams are responsible for the content (the questions asked) and form (Excel spreadsheet to download, complete and return; or online questionnaire) of their respective surveys. Survey Data Collection does need some personal data in its own right for the functioning of the platform.</p>
-                    <p>The lawful reason for which your personal data is collected through the Survey Data Collection platform is Public task. The processing is necessary for us to perform a task in the public interest or for our official functions, and the task or function has a clear basis in law.</p>
-
-
-                    <h2 class="neptune u-mt-l">
-                        When we collect your data
-                    </h2>
-
-                    <p>Your data is collected when:</p>
-                    <ul>
-                      <li>you create an account and sign in to the ONS Surveys platform</li>
-                      <li>you complete a survey</li>
-                      <li>you contact us by any means</li>
-                      <li>you visit a website that comprises the Survey Data Collection platform</li>
-                    </ul>
-
-
-                    <h2 class="neptune u-mt-l">
-                        What data we collect
-                    </h2>
-
-
-                    <div>
-                        <p><strong>Personal data items required for the operation of the Survey Data Collection Platform:</strong></p>
-
-                        <table class="table">
-                            <thead class="table__head">
-                                <tr>
-                                    <th class="table__header-cell">Data item</th>
-                                    <th class="table__header-cell">Description</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td class="table__cell">Email address</td>
-                                    <td class="table__cell">
-                                        <p>Survey Data Collection captures and stores the email address of those who register with the platform. Registration is required in order to complete a survey return.</p>
-                                        <p>Email address is used as a unique user identifier. Once registered the email address and password created is required to identify you each time you use the service.</p>
-                                        <p>Additionally, the email address is used to send communications for purposes of account management and reminders of survey responses.</p>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td class="table__cell">Business Name</td>
-                                    <td class="table__cell">
-                                        <p>Business names are pre-loaded into the Survey Data Collection platform as part of a business having been selected for a survey.</p>
-                                        <p>The name of the business that has been selected for a given survey will have been provided to Survey Data Collection another part of the Office for National Statistics responsible for the survey in question. Survey Data Collection stores and processes this.</p>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td class="table__cell">IP address</td>
-                                    <td class="table__cell">
-                                        <p>Internet Protocol address</p>
-                                        <p>All devices connected to the internet will have an IP address and this is used for one device (e.g. the computer you use to provide a survey response at your place of work) to be able to talk to another (e.g. the Survey Data Collection web site) over the internet.</p>
-                                        <p>The logs of IP address activity against the Survey Data Collection service are kept for a limited period of time to facilitate investigations in the case of any problems.</p>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-
-                        <p>Surveys that are conducted on the Survey Data Collection platform may collect additional items of personal data.</p>
-
-                        <h3 class="venus">Business surveys that require personal data</h3>
-                        <p><a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/annualsurveyofhoursandearningsashe">Annual Survey of Hours and Earnings</a><br>The legal basis for undertaking the Annual Survey of Hours and Earnings (ASHE) is the Statistics of Trade Act 1947.  This means the General Data Protection Regulation has not changed the fact that this is mandatory for the organisations selected to be part of the sample.  The personal data an organisation returns as part of this submission does not require the permission of the employees who form the data subjects and the subjects do not have any option to opt-out. The ASHE survey collects the following items of personal data:</p>
-                        <ul>
-                            <li>National insurance number</li>
-                            <li>Date of birth</li>
-                            <li>Postcode</li>
-                        </ul>
-
-                        <h3 class="venus">Communication outside of the Survey Data Collection Platform</h3>
-                        <p>The Survey Data Collection platform contains both a telephone number and email address which can be used for both queries and issues with the platform and survey hosted on the platform.</p>
-                        <p>If you contact us via email, we will process the following data items:</p>
-                        <ul>
-                            <li>Email address</li>
-                            <li>IP address of the server from which the email was sent</li>
-                            <li>Any items of personal data within the email</li>
-                        </ul>
-
-                        <p>If you contact us via telephone, we will process the following data items:</p>
-                        <ul>
-                            <li>Telephone number</li>
-                            <li>Name of the caller</li>
-                            <li>Any items of personal data disclosed during the call</li>
-                        </ul>
-                    </div>
-
-                    <h2 class="neptune u-mt-l">
-                        Who we share your personal data with
-                    </h2>
-                    <div class="mars">
-                        <p>We use several (1st and 3rd) parties to collect and process personal data. These include (but are not limited to) government departments and approved researchers. Further information can be found on the following articles: </p>
-                        <p><a href="https://www.ons.gov.uk/aboutus/whatwedo/statistics/requestingstatistics/approvedresearcherscheme">Approved Researcher Scheme</a><br>
-                        <p><a href="https://www.ons.gov.uk/aboutus/whatwedo/statistics/requestingstatistics/accesstounpublishedonsresearchdatabygovernmentorganisationsforstatisticalresearch">Access to unpublished ONS research data by government organisations for statistical research</a></p>
-                        <p>Data is also processed by 3rd party IT companies who support our systems for the following purposes:</p>
-                        <table class="table">
-                            <thead class="table__head">
-                                <tr>
-                                    <th class="table__header-cell">Purpose</th>
-                                    <th class="table__header-cell">Description</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td class="table__cell">Cloud infrastructure</td>
-                                    <td class="table__cell">Used to support the platform on which the Survey Data Collection service runs.</td>
-                                </tr>
-                                <tr>
-                                    <td class="table__cell">Email notification service</td>
-                                    <td class="table__cell">A service used to send email messages to the active accounts registered to the Survey Data Collection service.</td>
-                                </tr>
-                                <tr>
-                                    <td class="table__cell">Secure file transfer</td>
-                                    <td class="table__cell">This is used for the behind the scenes transfer of data that identify the businesses that have been selected for participation in a given survey.</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-
-                    <h2 class="neptune u-mt-l">
-                        How long we keep your data
-                    </h2>
-                    <div class="mars">
-                        <h3 class="venus"><strong>Log Retention</strong></h3>
-                        <p>Standard logs from the Survey Data Collection service are retained for a period of 30 days. Exceptional events may be retained for longer.</p>
-                        <p>Our general retention period for data collected via annual surveys is 3 years.</p>
-                        <p>Personal data used for account access will be retained as long as the account is active.</p>
-                    </div>
-
-                    <h2 class="neptune u-mt-l">
-                        Your rights over your personal data
-                    </h2>
-                    <div class="mars">
-                        <p>The General Data Protection Regulation (GDPR) details eight rights of individuals:</p>
-                        <ol>
-                            <li>The right to be informed</li>
-                            <li>The right of access *</li>
-                            <li>The right to rectification *</li>
-                            <li>The right to erasure *</li>
-                            <li>The right to restrict processing *</li>
-                            <li>The right to data portability * <br><emphasis>This right only exists if the lawful basis used is either consent or contract. Neither the Survey Data Collection service nor any surveys hosted on this platform rely on either of the lawful basis and therefore this right is not applicable.</emphasis></li>
-                            <li>The right to object *</li>
-                            <li>Rights in relation to automated decision making and profiling.<br><emphasis>No automated decision making or profiling occurs at the personal level.</emphasis></li>
-                        </ol>
-                        <p> * These rights are subject to exemptions.</p>
-                    </div>
-
-                    <h2 class="neptune u-mt-l">
-                        Contacting the Data Protection Office
-                    </h2>
-                    <div class="mars">
-                        <p>The Data Protection Officer for the Office for National Statistics can be contacted as follows:</p>
-                        <p>Office for National Statistics<br>Segensworth Road<br>Titchfield<br>Fareham<br>Hampshire<br>PO15 5RR</p>
-                        <p>Telephone: 0845 601 3034<br>Email: <a href="mailto:dpo@statistics.gov.uk">dpo@statistics.gov.uk</a></p>
-                    </div>
-
-                    <h2 class="neptune u-mt-l">
-                        Contacting the Information Commissioner's Office
-                    </h2>
-                    <div class="mars">
-                        <p>We welcome the opportunity to be able to answer any questions or concerns you may have around the information provided here. If you are unhappy with our response to any of your requests or you have concerns around how your data has been handled, you have the right to lodge a complaint with the Information Commissioner's Office.</p>
-                        <p>Information Commissioner’s Office<br>Wycliffe House<br>Water Lane<br>Wilmslow<br>Cheshire<br>SK9 5AF</p>
-                        <p>Telephone: 0303 123 1113<br>Email: <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a></p>
-                        <p>The Information Commissioner's Office provides guidance to the public on raising a concern with an organisation at the following location: <a href="https://ico.org.uk/for-the-public/raising-concerns/">https://ico.org.uk/for-the-public/raising-concerns/</a></p>
-                    </div>
-
-                </div>
-
-{% endblock main %}
+    <h2 class="neptune u-mt-l">
+        Universal Analytics
+    </h2>
+
+
+    <table class="table">
+        <thead class="table__head table__header-cell--align">
+            <tr>
+                <th class="table__header-cell table__header-cell--align">Name</th>
+                <th class="table__header-cell">Purpose</th>
+                <th class="table__header-cell">Expires</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="table__row">
+                <td class="table__cell">_ga</td>
+                <td class="table__cell">This helps us count how many people visit our website by tracking if you’ve
+                    visited before</td>
+                <td class="table__cell nowrap">2 years</td>
+            </tr>
+            <tr class="table__row">
+                <td class="table__cell">_gid</td>
+                <td class="table__cell">This helps us count how many people visit our website by tracking if you’ve
+                    visited before</td>
+                <td class="table__cell nowrap">24 hours</td>
+            </tr>
+            <tr class="table__row">
+                <td class="table__cell">_gat</td>
+                <td class="table__cell">Used to manage the rate at which page view requests are made</td>
+                <td class="table__cell nowrap">10 minutes</td>
+            </tr>
+        </tbody>
+    </table>
+
+
+
+
+    <h2 class="neptune u-mt-l">
+        Completing a survey (eq.ons.gov.uk)
+    </h2>
+
+
+    <table class="table">
+        <thead class="table__head">
+            <tr>
+                <th class="table__header-cell">Name</th>
+                <th class="table__header-cell">Purpose</th>
+                <th class="table__header-cell">Expires</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="table__row">
+                <td class="table__cell">Session</td>
+                <td class="table__cell">To keep you signed in when completing a survey</td>
+                <td class="table__cell">When a user logs out or closes the browser. Or when
+                    their cookie cache is cleared
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h2 class="neptune u-mt-l">
+        Data controller
+    </h2>
+
+    <p>The Data Controller for ONS Surveys is:</p>
+    <p>Office for National Statistics<br>Government Buildings<br>Cardiff Road<br>Newport<br>South Wales<br>NP10 8XG</p>
+    <p>For questions regarding the Survey Data Collection service please contact us on:</p>
+    <p>Telephone: <a href="tel:08000857376">0800 085 7376</a></p>
+
+
+    <h2 class="neptune u-mt-l">
+        Why we collect your data
+    </h2>
+
+    <p>The Survey Data Collection service is used as the online collection mechanism for a number of our surveys. More
+        surveys will be offered via this service over time.</p>
+    <p>Individual survey teams are responsible for the content (the questions asked) of their respective surveys. Survey Data Collection
+        does need some personal data in its own right for the functioning of the platform.</p>
+    <p>UK legislation allows us to collect and process your data to produce statistics
+        for the public good. Your information will be treated as confidential by the
+        Code of Practice for Official Statistics.</p>
+
+
+    <h2 class="neptune u-mt-l">
+        When we collect your data
+    </h2>
+
+    <p>Your data is collected when:</p>
+    <ul>
+        <li>you and sign in to the ONS Surveys platform</li>
+        <li>you complete a survey</li>
+        <li>you contact us by any means</li>
+        <li>you visit a website that comprises the Survey Data Collection platform</li>
+    </ul>
+
+
+    <h2 class="neptune u-mt-l">
+        What data we collect
+    </h2>
+
+
+    <div>
+        <p><strong>Personal data items required for the operation of the Survey Data Collection Platform:</strong></p>
+
+        <table class="table">
+            <thead class="table__head">
+                <tr>
+                    <th class="table__header-cell">Data item</th>
+                    <th class="table__header-cell">Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="table__cell">IP address</td>
+                    <td class="table__cell">
+                        <p>Internet Protocol address</p>
+                        <p>All devices connected to the internet will have an IP address and this is used for one
+                            device (e.g. the computer you use to provide a survey response at your place of work) to be
+                            able to talk to another (e.g. the Survey Data Collection web site) over the internet.</p>
+                        <p>The logs of IP address activity against the Survey Data Collection service are kept for a
+                            limited period of time to facilitate investigations in the case of any problems.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+        <p>Surveys that are conducted on the Survey Data Collection platform may collect additional items of personal
+            data.</p>
+
+        <ul>
+            <li>Online Household Study</li>
+            <ul>
+                <li>The Online Household Study is a UK-wide online study which covers a range of topics including work, retirement, higher education, unemployment and looking after the family or home.</li>
+                <li>The study collects the following items of personal data:</li>
+                <ul>
+                    <li>Date of Birth</li>
+                </ul>
+            </ul>
+        </ul>
+        <p>Participating in the study, as well as specific questions within the study, is voluntary.</p>
+
+        <h3 class="venus">Communication outside of the Survey Data Collection Platform</h3>
+        <p>The Survey Data Collection platform contains both a telephone number and email address which can be used for
+            both queries and issues with the platform and survey hosted on the platform.</p>
+        <p>If you contact us via email, we will process the following data items:</p>
+        <ul>
+            <li>Email address</li>
+            <li>IP address of the server from which the email was sent</li>
+            <li>Any items of personal data within the email</li>
+        </ul>
+
+        <p>If you contact us via telephone, we will process the following data items:</p>
+        <ul>
+            <li>Telephone number</li>
+            <li>Name of the caller</li>
+            <li>Any items of personal data disclosed during the call</li>
+        </ul>
+    </div>
+
+    <h2 class="neptune u-mt-l">
+        Who we share your personal data with
+    </h2>
+    <div class="mars">
+        <p>We use several (1st and 3rd) parties to collect and process personal data. These include (but are not
+            limited to) government departments and approved researchers. Further information can be found on the
+            following articles: </p>
+        <p><a href="https://www.ons.gov.uk/aboutus/whatwedo/statistics/requestingstatistics/approvedresearcherscheme">Approved
+                Researcher Scheme</a><br>
+            <p><a href="https://www.ons.gov.uk/aboutus/whatwedo/statistics/requestingstatistics/accesstounpublishedonsresearchdatabygovernmentorganisationsforstatisticalresearch">Access
+                    to unpublished ONS research data by government organisations for statistical research</a></p>
+            <p>Data is also processed by 3rd party IT companies who support our systems for the following purposes:</p>
+            <table class="table">
+                <thead class="table__head">
+                    <tr>
+                        <th class="table__header-cell">Purpose</th>
+                        <th class="table__header-cell">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="table__cell">Cloud infrastructure</td>
+                        <td class="table__cell">Used to support the platform on which the Survey Data Collection
+                            service runs.</td>
+                    </tr>
+                    <tr>
+                        <td class="table__cell">Secure file transfer</td>
+                        <td class="table__cell">This is used for the behind the scenes transfer of data that identify
+                            the businesses that have been selected for participation in a given survey.</td>
+                    </tr>
+                </tbody>
+            </table>
+    </div>
+
+    <h2 class="neptune u-mt-l">
+        How long we keep your data
+    </h2>
+    <div class="mars">
+        <h3 class="venus"><strong>Log Retention</strong></h3>
+        <p>Standard logs from the Survey Data Collection service are retained for a period of 30 days. Exceptional
+            events may be retained for longer.</p>
+        <p>Our general retention period for data collected via social surveys is 5 years.</p>
+    </div>
+
+    <h2 class="neptune u-mt-l">
+        Your rights over your personal data
+    </h2>
+    <div class="mars">
+        <p>The General Data Protection Regulation (GDPR) details eight rights of individuals:</p>
+        <ol>
+            <li>The right to be informed</li>
+            <li>The right of access *</li>
+            <li>The right to rectification *</li>
+            <li>The right to erasure *</li>
+            <li>The right to restrict processing *</li>
+            <li>The right to data portability * <br>
+                <emphasis>This right only exists if the lawful basis used is either consent or contract. Neither the
+                    Survey Data Collection service nor any surveys hosted on this platform rely on either of the lawful
+                    basis and therefore this right is not applicable.</emphasis>
+            </li>
+            <li>The right to object *</li>
+            <li>Rights in relation to automated decision making and profiling.<br>
+                <emphasis>No automated decision making or profiling occurs at the personal level.</emphasis>
+            </li>
+        </ol>
+        <p> * These rights are subject to exemptions.</p>
+    </div>
+
+    <h2 class="neptune u-mt-l">
+        Contacting the Data Protection Office
+    </h2>
+    <div class="mars">
+        <p>The Data Protection Officer for the Office for National Statistics can be contacted as follows:</p>
+        <p>Office for National Statistics<br>Segensworth Road<br>Titchfield<br>Fareham<br>Hampshire<br>PO15 5RR</p>
+        <p>Telephone: 0845 601 3034<br>Email: <a href="mailto:dpo@statistics.gov.uk">dpo@statistics.gov.uk</a></p>
+    </div>
+
+    <h2 class="neptune u-mt-l">
+        Contacting the Information Commissioner's Office
+    </h2>
+    <div class="mars">
+        <p>We welcome the opportunity to be able to answer any questions or concerns you may have around the
+            information provided here. If you are unhappy with our response to any of your requests or you have
+            concerns around how your data has been handled, you have the right to lodge a complaint with the
+            Information Commissioner's Office.</p>
+        <p>Information Commissioner’s Office<br>Wycliffe House<br>Water Lane<br>Wilmslow<br>Cheshire<br>SK9 5AF</p>
+        <p>Telephone: 0303 123 1113<br>Email: <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a></p>
+        <p>The Information Commissioner's Office provides guidance to the public on raising a concern with an
+            organisation at the following location: <a href="https://ico.org.uk/for-the-public/raising-concerns/">https://ico.org.uk/for-the-public/raising-concerns/</a></p>
+    </div>
+
+</div>
+
+{% endblock content %}

--- a/app/templates/cookies-privacy.html
+++ b/app/templates/cookies-privacy.html
@@ -108,30 +108,30 @@
 
 
     <table class="table">
-        <thead class="table__head table__header-cell--align">
+        <thead class="table--head">
             <tr>
-                <th class="table__header-cell table__header-cell--align">Name</th>
-                <th class="table__header-cell">Purpose</th>
-                <th class="table__header-cell">Expires</th>
+                <th scope="col" class="table--header--cell">Name</th>
+                <th scope="col" class="table--header--cell">Purpose</th>
+                <th scope="col" class="table--header--cell">Expires</th>
             </tr>
         </thead>
         <tbody>
             <tr class="table__row">
-                <td class="table__cell">_ga</td>
-                <td class="table__cell">This helps us count how many people visit our website by tracking if you’ve
+                <td class="table--cell">_ga</td>
+                <td class="table--cell">This helps us count how many people visit our website by tracking if you’ve
                     visited before</td>
-                <td class="table__cell nowrap">2 years</td>
+                <td class="table--cell nowrap">2 years</td>
             </tr>
             <tr class="table__row">
-                <td class="table__cell">_gid</td>
-                <td class="table__cell">This helps us count how many people visit our website by tracking if you’ve
+                <td class="table--cell">_gid</td>
+                <td class="table--cell">This helps us count how many people visit our website by tracking if you’ve
                     visited before</td>
-                <td class="table__cell nowrap">24 hours</td>
+                <td class="table--cell nowrap">24 hours</td>
             </tr>
             <tr class="table__row">
-                <td class="table__cell">_gat</td>
-                <td class="table__cell">Used to manage the rate at which page view requests are made</td>
-                <td class="table__cell nowrap">10 minutes</td>
+                <td class="table--cell">_gat</td>
+                <td class="table--cell">Used to manage the rate at which page view requests are made</td>
+                <td class="table--cell nowrap">10 minutes</td>
             </tr>
         </tbody>
     </table>
@@ -147,16 +147,16 @@
     <table class="table">
         <thead class="table__head">
             <tr>
-                <th class="table__header-cell">Name</th>
-                <th class="table__header-cell">Purpose</th>
-                <th class="table__header-cell">Expires</th>
+                <th scope="col" class="table--header--cell">Name</th>
+                <th scope="col" class="table--header--cell">Purpose</th>
+                <th scope="col" class="table--header--cell">Expires</th>
             </tr>
         </thead>
         <tbody>
             <tr class="table__row">
-                <td class="table__cell">Session</td>
-                <td class="table__cell">To keep you signed in when completing a survey</td>
-                <td class="table__cell">When a user logs out or closes the browser. Or when
+                <td class="table--cell">Session</td>
+                <td class="table--cell">To keep you signed in when completing a survey</td>
+                <td class="table--cell">When a user logs out or closes the browser. Or when
                     their cookie cache is cleared
                 </td>
             </tr>
@@ -210,14 +210,14 @@
         <table class="table">
             <thead class="table__head">
                 <tr>
-                    <th class="table__header-cell">Data item</th>
-                    <th class="table__header-cell">Description</th>
+                    <th scope="col" class="table--header--cell">Data item</th>
+                    <th scope="col" class="table--header--cell">Description</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td class="table__cell">IP address</td>
-                    <td class="table__cell">
+                    <td class="table--cell">IP address</td>
+                    <td class="table--cell">
                         <p>Internet Protocol address</p>
                         <p>All devices connected to the internet will have an IP address and this is used for one
                             device (e.g. the computer you use to provide a survey response at your place of work) to be
@@ -233,14 +233,16 @@
             data.</p>
 
         <ul>
-            <li>Online Household Study</li>
-            <ul>
-                <li>The Online Household Study is a UK-wide online study which covers a range of topics including work, retirement, higher education, unemployment and looking after the family or home.</li>
-                <li>The study collects the following items of personal data:</li>
+            <li>Online Household Study
                 <ul>
-                    <li>Date of Birth</li>
+                    <li>The Online Household Study is a UK-wide online study which covers a range of topics including work, retirement, higher education, unemployment and looking after the family or home.</li>
+                    <li>The study collects the following items of personal data:
+                        <ul>
+                            <li>Date of Birth</li>
+                        </ul>
+                    </li>
                 </ul>
-            </ul>
+            </li>
         </ul>
         <p>Participating in the study, as well as specific questions within the study, is voluntary.</p>
 
@@ -277,19 +279,19 @@
             <table class="table">
                 <thead class="table__head">
                     <tr>
-                        <th class="table__header-cell">Purpose</th>
-                        <th class="table__header-cell">Description</th>
+                        <th scope="col" class="table--header--cell">Purpose</th>
+                        <th scope="col" class="table--header--cell">Description</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td class="table__cell">Cloud infrastructure</td>
-                        <td class="table__cell">Used to support the platform on which the Survey Data Collection
+                        <td class="table--cell">Cloud infrastructure</td>
+                        <td class="table--cell">Used to support the platform on which the Survey Data Collection
                             service runs.</td>
                     </tr>
                     <tr>
-                        <td class="table__cell">Secure file transfer</td>
-                        <td class="table__cell">This is used for the behind the scenes transfer of data that identify
+                        <td class="table--cell">Secure file transfer</td>
+                        <td class="table--cell">This is used for the behind the scenes transfer of data that identify
                             the businesses that have been selected for participation in a given survey.</td>
                     </tr>
                 </tbody>
@@ -318,13 +320,13 @@
             <li>The right to erasure *</li>
             <li>The right to restrict processing *</li>
             <li>The right to data portability * <br>
-                <emphasis>This right only exists if the lawful basis used is either consent or contract. Neither the
+                <em>This right only exists if the lawful basis used is either consent or contract. Neither the
                     Survey Data Collection service nor any surveys hosted on this platform rely on either of the lawful
-                    basis and therefore this right is not applicable.</emphasis>
+                    basis and therefore this right is not applicable.</em>
             </li>
             <li>The right to object *</li>
             <li>Rights in relation to automated decision making and profiling.<br>
-                <emphasis>No automated decision making or profiling occurs at the personal level.</emphasis>
+                <em>No automated decision making or profiling occurs at the personal level.</em>
             </li>
         </ol>
         <p> * These rights are subject to exemptions.</p>

--- a/app/templates/cookies-privacy.html
+++ b/app/templates/cookies-privacy.html
@@ -1,0 +1,437 @@
+
+{% block page_title %}Cookies and privacy - ONS Business Surveys{% endblock %}
+
+{% block main %}
+
+                <h1 class="saturn">
+                    Cookies and Privacy
+                </h1>
+
+                <p>The Office for National Statistics (ONS) has created this cookies and privacy
+                    statement in order to demonstrate our firm commitment to privacy.</p>
+
+                <p>The following is a description of what data is collected when you use this service,
+                    how it is stored and what it is used for.</p>
+
+                <div>
+                    <h2 class="neptune u-mt-l">
+                        Privacy
+                    </h2>
+
+                    <div>
+                        <p>Your privacy is very important to us. We comply with confidentiality
+                            requirements set out in the Statistics and Registration Service Act 2007 and
+                            the Data Protection Act 1998.</p>
+
+                        <p>We can only use your information for research and statistical purposes. None
+                            of your personal information is disclosed through our statistics.</p>
+
+                    </div>
+
+                    <h2 class="neptune u-mt-l">
+                        Security
+                    </h2>
+
+                    <div>
+                        <p>We ensure that the information you provide is kept safe and secure. We have
+                            security measures in place to protect the loss, misuse and alteration of
+                            information under our control.</p>
+
+                        <p>We use leading security technologies such as industry-standard encryption
+                            software. This service has been accredited in accordance with government
+                            technical and security standards.</p>
+                    </div>
+
+                    <h2 class="neptune u-mt-l">
+                        Cookies
+                    </h2>
+
+                    <div>
+                        <p>We use small files (known as ‘cookies’) to collect information about how you
+                            browse the site.</p>
+
+                        <p>Cookies are used to:</p>
+
+                        <ul>
+                            <li>Measure how you use the website so it can be updated and improved based
+                                on your needs
+                            </li>
+                            <li>Remember the notifications you’ve seen so that we don’t show them to you
+                                again
+                            </li>
+                        </ul>
+
+                        <p><strong>Our cookies are not used to identify you personally.</strong></p>
+                    </div>
+
+                    <h2 class="neptune u-mt-l">
+                        How cookies are used
+                    </h2>
+
+                    <div>
+                        <p><strong>Measuring website usage (Google Analytics)</strong></p>
+
+                        <p>We use Google Analytics software to collect information about how you use
+                            this service. We do this to help make sure the site is meeting the needs of
+                            its users and to help us make improvements, for example improving site
+                            search.</p>
+
+                        <p>Google Analytics stores information about:</p>
+
+                        <ul>
+                            <li>The pages you visit</li>
+                            <li>How long you spend on each page</li>
+                            <li>How you got to the site</li>
+                            <li>What you click on while you’re visiting the site</li>
+                        </ul>
+
+                        <p>We don’t use Google Analytics to collect or store your personal information
+                            (for example your name or address).</p>
+
+                        <p>The information we collect through our cookies does not include personal
+                            details such as your name, age, telephone number, postal address or email
+                            address, nor does it allow personal identification of a user.</p>
+
+                        <p>You can manage these small files yourself and learn more about them through
+                            <a href="https://www.aboutcookies.org/">internet browser cookies – what they
+                                are and how to manage them.</a></p>
+
+                    </div>
+
+
+
+
+                    <h2 class="neptune u-mt-l">
+                        Universal Analytics
+                    </h2>
+
+
+                    <table class="table">
+                      <thead class="table__head table__header-cell--align">
+                        <tr>
+                          <th class="table__header-cell table__header-cell--align">Name</th>
+                          <th class="table__header-cell">Purpose</th>
+                          <th class="table__header-cell">Expires</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="table__row">
+                          <td class="table__cell">_ga</td>
+                          <td class="table__cell">This helps us count how many people visit our website by tracking if you’ve visited before</td>
+                          <td class="table__cell nowrap">2 years</td>
+                        </tr>
+                        <tr class="table__row">
+                          <td class="table__cell">_gid</td>
+                          <td class="table__cell">This helps us count how many people visit our website by tracking if you’ve visited before</td>
+                          <td class="table__cell nowrap">24 hours</td>
+                        </tr>
+                        <tr class="table__row">
+                          <td class="table__cell">_gat</td>
+                          <td class="table__cell">Used to manage the rate at which page view requests are made</td>
+                          <td class="table__cell nowrap">10 minutes</td>
+                        </tr>
+                      </tbody>
+                    </table>
+
+
+
+
+                    <h2 class="neptune u-mt-l">
+                        Completing a survey (eq.ons.gov.uk)
+                    </h2>
+
+
+                    <table class="table">
+                        <thead class="table__head">
+                        <tr>
+                            <th class="table__header-cell">Name</th>
+                            <th class="table__header-cell">Purpose</th>
+                            <th class="table__header-cell">Expires</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr class="table__row">
+                            <td class="table__cell">Session</td>
+                            <td class="table__cell">To keep you signed in when completing a survey</td>
+                            <td class="table__cell">When a user logs out or closes the browser. Or when
+                                their cookie cache is cleared
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+
+
+
+
+                    <h2 class="neptune u-mt-l">
+                        Your account (surveys.ons.gov.uk)
+                    </h2>
+
+
+                    <table class="table">
+                        <thead class="table__head">
+                        <tr>
+                            <th class="table__header-cell">Name</th>
+                            <th class="table__header-cell">Purpose</th>
+                            <th class="table__header-cell">Expires</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td class="table__cell">COOKIE_SUPPORT</td>
+                            <td class="table__cell">To check that your browser can support cookies</td>
+                            <td class="table__cell">When a user closes the browser or when their cookie
+                                cache is cleared
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="table__cell">GUEST_LANGUAGE_ID</td>
+                            <td class="table__cell">To store your preferred language so that certain
+                                content can be displayed in your own language
+                            </td>
+                            <td class="table__cell">When a user closes the browser or when their cookie
+                                cache is cleared
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="table__cell">JSESSIONID</td>
+                            <td class="table__cell">To keep your session active when using your account
+                                to access portfolio and messages
+                            </td>
+                            <td class="table__cell">When a user closes the browser or when their cookie
+                                cache is cleared
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="table__cell">ID</td>
+                            <td class="table__cell">To store an encrypted identifier which is used to
+                                retrieve the information associated to your account
+                            </td>
+                            <td class="table__cell">When a user logs out or closes the browser or when
+                                their cookie cache is cleared
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="table__cell">COMPANY_ID</td>
+                            <td class="table__cell">To store an identifier which is used to retrieve the
+                                permissions associated to your account
+                            </td>
+                            <td class="table__cell">When a user logs out or closes the browser or when
+                                their cookie cache is cleared
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="table__cell">USER_UUID</td>
+                            <td class="table__cell">To store the universally unique identifier created
+                                for your account
+                            </td>
+                            <td class="table__cell">When a user closes the browser or when their cookie
+                                cache is cleared
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="table__cell">LFR_SESSION_STATE_*</td>
+                            <td class="table__cell">To store the timestamp of the last request so that
+                                the session expiry warning message can be displayed
+                            </td>
+                            <td class="table__cell">When a user closes the browser or when their cookie
+                                cache is cleared
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="table__cell">csfcfc</td>
+                            <td class="table__cell">To store the flash object identifier for the most
+                                recent action you have performed
+                            </td>
+                            <td class="table__cell">When a user closes the browser or when their cookie
+                                cache is cleared
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+
+
+
+
+                    <h2 class="neptune u-mt-l">
+                        Data controller
+                    </h2>
+
+                    <p>The Data Controller for ONS Surveys is:</p><p>Office for National Statistics<br>Government Buildings<br>Cardiff Road<br>Newport<br>South Wales<br>NP10 8XG</p>
+                    <p>For questions regarding the Survey Data Collection service please contact us on:</p>
+                    <p>Telephone: <a href="tel:03001234931">0300 1234 931</a></p>
+
+
+                    <h2 class="neptune u-mt-l">
+                        Why we collect your data
+                    </h2>
+
+                    <p>The Survey Data Collection service is used as the online collection mechanism for a number of our surveys. More surveys will be offered via this service over time.</p>
+                    <p>Individual survey teams are responsible for the content (the questions asked) and form (Excel spreadsheet to download, complete and return; or online questionnaire) of their respective surveys. Survey Data Collection does need some personal data in its own right for the functioning of the platform.</p>
+                    <p>The lawful reason for which your personal data is collected through the Survey Data Collection platform is Public task. The processing is necessary for us to perform a task in the public interest or for our official functions, and the task or function has a clear basis in law.</p>
+
+
+                    <h2 class="neptune u-mt-l">
+                        When we collect your data
+                    </h2>
+
+                    <p>Your data is collected when:</p>
+                    <ul>
+                      <li>you create an account and sign in to the ONS Surveys platform</li>
+                      <li>you complete a survey</li>
+                      <li>you contact us by any means</li>
+                      <li>you visit a website that comprises the Survey Data Collection platform</li>
+                    </ul>
+
+
+                    <h2 class="neptune u-mt-l">
+                        What data we collect
+                    </h2>
+
+
+                    <div>
+                        <p><strong>Personal data items required for the operation of the Survey Data Collection Platform:</strong></p>
+
+                        <table class="table">
+                            <thead class="table__head">
+                                <tr>
+                                    <th class="table__header-cell">Data item</th>
+                                    <th class="table__header-cell">Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="table__cell">Email address</td>
+                                    <td class="table__cell">
+                                        <p>Survey Data Collection captures and stores the email address of those who register with the platform. Registration is required in order to complete a survey return.</p>
+                                        <p>Email address is used as a unique user identifier. Once registered the email address and password created is required to identify you each time you use the service.</p>
+                                        <p>Additionally, the email address is used to send communications for purposes of account management and reminders of survey responses.</p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="table__cell">Business Name</td>
+                                    <td class="table__cell">
+                                        <p>Business names are pre-loaded into the Survey Data Collection platform as part of a business having been selected for a survey.</p>
+                                        <p>The name of the business that has been selected for a given survey will have been provided to Survey Data Collection another part of the Office for National Statistics responsible for the survey in question. Survey Data Collection stores and processes this.</p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="table__cell">IP address</td>
+                                    <td class="table__cell">
+                                        <p>Internet Protocol address</p>
+                                        <p>All devices connected to the internet will have an IP address and this is used for one device (e.g. the computer you use to provide a survey response at your place of work) to be able to talk to another (e.g. the Survey Data Collection web site) over the internet.</p>
+                                        <p>The logs of IP address activity against the Survey Data Collection service are kept for a limited period of time to facilitate investigations in the case of any problems.</p>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <p>Surveys that are conducted on the Survey Data Collection platform may collect additional items of personal data.</p>
+
+                        <h3 class="venus">Business surveys that require personal data</h3>
+                        <p><a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/annualsurveyofhoursandearningsashe">Annual Survey of Hours and Earnings</a><br>The legal basis for undertaking the Annual Survey of Hours and Earnings (ASHE) is the Statistics of Trade Act 1947.  This means the General Data Protection Regulation has not changed the fact that this is mandatory for the organisations selected to be part of the sample.  The personal data an organisation returns as part of this submission does not require the permission of the employees who form the data subjects and the subjects do not have any option to opt-out. The ASHE survey collects the following items of personal data:</p>
+                        <ul>
+                            <li>National insurance number</li>
+                            <li>Date of birth</li>
+                            <li>Postcode</li>
+                        </ul>
+
+                        <h3 class="venus">Communication outside of the Survey Data Collection Platform</h3>
+                        <p>The Survey Data Collection platform contains both a telephone number and email address which can be used for both queries and issues with the platform and survey hosted on the platform.</p>
+                        <p>If you contact us via email, we will process the following data items:</p>
+                        <ul>
+                            <li>Email address</li>
+                            <li>IP address of the server from which the email was sent</li>
+                            <li>Any items of personal data within the email</li>
+                        </ul>
+
+                        <p>If you contact us via telephone, we will process the following data items:</p>
+                        <ul>
+                            <li>Telephone number</li>
+                            <li>Name of the caller</li>
+                            <li>Any items of personal data disclosed during the call</li>
+                        </ul>
+                    </div>
+
+                    <h2 class="neptune u-mt-l">
+                        Who we share your personal data with
+                    </h2>
+                    <div class="mars">
+                        <p>We use several (1st and 3rd) parties to collect and process personal data. These include (but are not limited to) government departments and approved researchers. Further information can be found on the following articles: </p>
+                        <p><a href="https://www.ons.gov.uk/aboutus/whatwedo/statistics/requestingstatistics/approvedresearcherscheme">Approved Researcher Scheme</a><br>
+                        <p><a href="https://www.ons.gov.uk/aboutus/whatwedo/statistics/requestingstatistics/accesstounpublishedonsresearchdatabygovernmentorganisationsforstatisticalresearch">Access to unpublished ONS research data by government organisations for statistical research</a></p>
+                        <p>Data is also processed by 3rd party IT companies who support our systems for the following purposes:</p>
+                        <table class="table">
+                            <thead class="table__head">
+                                <tr>
+                                    <th class="table__header-cell">Purpose</th>
+                                    <th class="table__header-cell">Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="table__cell">Cloud infrastructure</td>
+                                    <td class="table__cell">Used to support the platform on which the Survey Data Collection service runs.</td>
+                                </tr>
+                                <tr>
+                                    <td class="table__cell">Email notification service</td>
+                                    <td class="table__cell">A service used to send email messages to the active accounts registered to the Survey Data Collection service.</td>
+                                </tr>
+                                <tr>
+                                    <td class="table__cell">Secure file transfer</td>
+                                    <td class="table__cell">This is used for the behind the scenes transfer of data that identify the businesses that have been selected for participation in a given survey.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <h2 class="neptune u-mt-l">
+                        How long we keep your data
+                    </h2>
+                    <div class="mars">
+                        <h3 class="venus"><strong>Log Retention</strong></h3>
+                        <p>Standard logs from the Survey Data Collection service are retained for a period of 30 days. Exceptional events may be retained for longer.</p>
+                        <p>Our general retention period for data collected via annual surveys is 3 years.</p>
+                        <p>Personal data used for account access will be retained as long as the account is active.</p>
+                    </div>
+
+                    <h2 class="neptune u-mt-l">
+                        Your rights over your personal data
+                    </h2>
+                    <div class="mars">
+                        <p>The General Data Protection Regulation (GDPR) details eight rights of individuals:</p>
+                        <ol>
+                            <li>The right to be informed</li>
+                            <li>The right of access *</li>
+                            <li>The right to rectification *</li>
+                            <li>The right to erasure *</li>
+                            <li>The right to restrict processing *</li>
+                            <li>The right to data portability * <br><emphasis>This right only exists if the lawful basis used is either consent or contract. Neither the Survey Data Collection service nor any surveys hosted on this platform rely on either of the lawful basis and therefore this right is not applicable.</emphasis></li>
+                            <li>The right to object *</li>
+                            <li>Rights in relation to automated decision making and profiling.<br><emphasis>No automated decision making or profiling occurs at the personal level.</emphasis></li>
+                        </ol>
+                        <p> * These rights are subject to exemptions.</p>
+                    </div>
+
+                    <h2 class="neptune u-mt-l">
+                        Contacting the Data Protection Office
+                    </h2>
+                    <div class="mars">
+                        <p>The Data Protection Officer for the Office for National Statistics can be contacted as follows:</p>
+                        <p>Office for National Statistics<br>Segensworth Road<br>Titchfield<br>Fareham<br>Hampshire<br>PO15 5RR</p>
+                        <p>Telephone: 0845 601 3034<br>Email: <a href="mailto:dpo@statistics.gov.uk">dpo@statistics.gov.uk</a></p>
+                    </div>
+
+                    <h2 class="neptune u-mt-l">
+                        Contacting the Information Commissioner's Office
+                    </h2>
+                    <div class="mars">
+                        <p>We welcome the opportunity to be able to answer any questions or concerns you may have around the information provided here. If you are unhappy with our response to any of your requests or you have concerns around how your data has been handled, you have the right to lodge a complaint with the Information Commissioner's Office.</p>
+                        <p>Information Commissioner’s Office<br>Wycliffe House<br>Water Lane<br>Wilmslow<br>Cheshire<br>SK9 5AF</p>
+                        <p>Telephone: 0303 123 1113<br>Email: <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a></p>
+                        <p>The Information Commissioner's Office provides guidance to the public on raising a concern with an organisation at the following location: <a href="https://ico.org.uk/for-the-public/raising-concerns/">https://ico.org.uk/for-the-public/raising-concerns/</a></p>
+                    </div>
+
+                </div>
+
+{% endblock main %}

--- a/app/templates/partials/footer.html
+++ b/app/templates/partials/footer.html
@@ -5,7 +5,7 @@
                 <p class="venus footer__heading"><strong>Legal information</strong></p>
                 <ul class="list list--bare">
                     <li>
-                        <a href="https://surveys.ons.gov.uk/cookies-privacy"
+                        <a href="/cookies-privacy"
                            class="footer__link">Cookies and privacy</a>
                     </li>
                 </ul>

--- a/app/templates/partials/footer.html
+++ b/app/templates/partials/footer.html
@@ -5,7 +5,7 @@
                 <p class="venus footer__heading"><strong>Legal information</strong></p>
                 <ul class="list list--bare">
                     <li>
-                        <a href="/cookies-privacy"
+                        <a href="{{ url('CookiesPrivacy:get') }}"
                            class="footer__link">Cookies and privacy</a>
                     </li>
                 </ul>

--- a/app/templates/partials/header.html
+++ b/app/templates/partials/header.html
@@ -4,7 +4,7 @@
       <div class="grid grid--gutterless">
         <div class="grid__col col-6@s">
           <div class="logo">
-            <a href="/">
+            <a href="{{ url('Index:get') }}">
               {% set logo_cdn = cdn_url_prefix~"/img/ons-logo-pos.svg" %}
               <img src="{{ logo_cdn }}" alt="Office for National Statistics logo" class="logo__img header__logo">
             </a>

--- a/app/templates/partials/header.html
+++ b/app/templates/partials/header.html
@@ -4,8 +4,10 @@
       <div class="grid grid--gutterless">
         <div class="grid__col col-6@s">
           <div class="logo">
+            <a href="/">
               {% set logo_cdn = cdn_url_prefix~"/img/ons-logo-pos.svg" %}
               <img src="{{ logo_cdn }}" alt="Office for National Statistics logo" class="logo__img header__logo">
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Motivation and Context
Create privacy page for social.

# What has changed
- New privacy page created.
- Pointed footer link to new page.
- Added logo link back to RH.

# How to test?
Check links work and content is correct (see: https://docs.google.com/viewerng/viewer?url=https://trello-attachments.s3.amazonaws.com/5a159c97a25f12ca639acf71/5b9a4c99a879363966d9d7a3/de6c76a030675e74ca318c23fb00bb45/Cookies_and_Privacy_(Social)_SBL_1.docx)

# Links
https://trello.com/c/d0U2sz8L/278-sus021-update-to-content-of-surveys-privacy-page-to-include-information-for-social-surveys