### PR TITLE
T007 Only apply security headers when not in debug mode

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -115,7 +115,8 @@ def create_app(config_name=None) -> Application:
 
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
-    app.on_response_prepare.append(security.on_prepare)
+    if not app.debug:
+        app.on_response_prepare.append(security.on_prepare)
 
     logger.info("App setup complete", config=config_name)
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -14,6 +14,8 @@ class TestCreateApp(AioHTTPTestCase):
     config = 'TestingConfig'
 
     async def get_application(self):
+        from app import settings
+        settings.DEBUG = False  # force security headers to be applied to response
         return create_app(self.config)
 
     @unittest_run_loop


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When running Respondent Home locally, an accompanying [aux server](https://github.com/aio-libs/aiohttp-devtools/) is usually started alongside on PORT+1. This additional server adds the functionality for live reloading, as well as other helpful dev tools. With security headers applied to the dev server these tools no longer function.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

- Disable security headers when running in debug mode.
- Force security headers to be applied when testing app creation.
