### PR TITLE
Change make targets to something more generic for use in pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ RM_TOOLS_REPO_URL = https://github.com/ONSdigital/rm-tools.git
 
 .PHONY: test unit_tests integration_tests
 
+build: install
+
 install:
 	pipenv install --dev
 
@@ -13,9 +15,11 @@ serve:
 run:
 	pipenv run inv run
 
-test: flake8 unittests start_services wait_for_services setup integration_tests stop_services
+test: flake8 unittests
 
-live_test: start_services wait_for_services setup integration_tests stop_services
+local_test:  start_services wait_for_services setup integration_tests stop_services
+
+live_test: start_services wait_for_services setup live_integration_tests stop_services
 
 start_services:
 	./scripts/start_ras_rm.sh ${RAS_RM_REPO_URL}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Following the [addition](https://github.com/ONSdigital/ras-deploy/pull/79) of a [re-usable unit test task](https://github.com/ONSdigital/ras-deploy/blob/95bc9ef4783759658f961010c7e713dfc414fd90/tasks/python-unit-tests.yml) in the deployment pipeline, we should make sure a project's Makefile targets are generic (e.g.: `make build`, `make test`, etc.).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- added `make build` as an alias for `pipenv install --dev`
- changed `make test` to only run the unit tests
- added `make local_test`, which runs the integration tests only