### PR TITLE
BUG303 Redirect prefixed paths missing a trailing slash to index

### DIFF
--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -22,6 +22,12 @@ def create_error_middleware(overrides):
             resp = await handler(request)
             override = overrides.get(resp.status)
             return await override(request) if override else resp
+        except web.HTTPNotFound as ex:
+            index_resource = request.app.router['Index:get']
+            if request.path + '/' == index_resource.canonical:
+                logger.debug('Redirecting to index', path=request.path)
+                raise web.HTTPMovedPermanently(index_resource.url_for())
+            raise ex
         except InvalidEqPayLoad as ex:
             return await eq_error(request, ex.message)
         except ClientConnectionError as ex:

--- a/tests/unit/test_error_handlers.py
+++ b/tests/unit/test_error_handlers.py
@@ -1,0 +1,27 @@
+from aiohttp.test_utils import unittest_run_loop
+
+from app.app import create_app
+from . import RHTestCase
+
+
+class TestErrorHandlers(RHTestCase):
+
+    config = 'TestingConfig'
+
+    async def get_application(self):
+        from app import config
+
+        url_prefix = '/url-path-prefix'
+        config.TestingConfig.URL_PATH_PREFIX = url_prefix
+        return create_app(self.config)
+
+    @unittest_run_loop
+    async def test_partial_path_redirects_to_index(self):
+        with self.assertLogs('respondent-home', 'DEBUG') as cm:
+            response = await self.client.request("GET", str(self.get_index).rstrip('/'))
+        self.assertLogLine(cm, 'Redirecting to index')
+        self.assertEqual(response.status, 200)
+        contents = await response.content.read()
+        self.assertIn(b'Your 12 character access code is on the letter we sent you', contents)
+        self.assertEqual(contents.count(b'input-text'), 3)
+        self.assertIn(b'type="submit"', contents)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Following the [removal of the static files](https://github.com/ONSdigital/respondent-home-ui/pull/59), a bug was introduced whereby an incomplete prefixed path would not resolve to index.

This manifested because previously a prefixed path such as `/mystudy` would go to the static root directory -> which we made inaccessible -> app raises 403 (forbidden) -> error handler redirects to index.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add a custom error handler for paths not found to check for an incomplete index route and redirect if possible (301)
- Reinstate unit test for redirecting to index

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- run the unit tests with `make unittests`
- start the server with `make run` and check routing with and without a URL_PATH_PREFIX environment variable
