### PR TITLE
SUS053: Create contact us content and page.

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -163,3 +163,10 @@ class CookiesPrivacy:
     @aiohttp_jinja2.template('cookies-privacy.html')
     async def get(self, _):
         return {}
+
+
+@routes.view('/contact-us')
+class ContactUs:
+    @aiohttp_jinja2.template('contact-us.html')
+    async def get(self, _):
+        return {}

--- a/app/templates/contact-us.html
+++ b/app/templates/contact-us.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}Contact us - My Study{% endblock title %}
+
+{% block content %}
+
+<h1 class="saturn">
+  Contact us
+</h1>
+<h2 class="neptune">
+  Telephone
+</h2>
+<p>
+  <a href="tel:08000857376">0800 085 7376</a>
+</p> 
+<p>NGT service (18001) 
+  <a href="tel:08000857376">0800 085 7376</a>
+</p>
+<h3 class="venus">Opening hours:</h3>
+<p>
+  Monday to Thursday 9am – 9pm<br>
+  Friday 9am - 8pm<br>
+  Saturday 9am - 1pm
+</p>
+<p>This office is closed during public holidays</p>
+<h2 class="neptune">
+    Email
+</h2>
+<p>
+  <a href="mailto:surveyfeedback@ons.gov.uk">surveyfeedback@ons.gov.uk</a>
+</p>
+<h2 class="neptune">
+  Post
+</h2>
+<p>Office for National Statistics<br>
+  Segensworth Road<br>
+  Titchfield<br>
+  Fareham<br>
+  PO15 5RR
+</p>
+
+{% endblock content %}

--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -9,7 +9,7 @@
 </h1>
 
 <p>We are experiencing some technical problems.</p>
-<p>Please try again later, or <a href="https://www.ons.gov.uk/aboutus/contactus">contact us</a> if the problem continues.</p>
+<p>Please try again later, or <a href="{{ url('ContactUs:get') }}">contact us</a> if the problem continues.</p>
 
 
 {% endblock content %}

--- a/app/templates/partials/footer.html
+++ b/app/templates/partials/footer.html
@@ -19,7 +19,7 @@
                            class="footer__link">What we do</a>
                     </li>
                     <li>
-                        <a href="https://www.ons.gov.uk/aboutus/contactus"
+                        <a href="{{ url('ContactUs:get') }}"
                            class="footer__link">Contact us</a>
                     </li>
                     <li>

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -210,6 +210,8 @@ class RHTestCase(AioHTTPTestCase):
 
         self.get_index = self.app.router['Index:get'].url_for()
         self.get_info = self.app.router['Info:get'].url_for()
+        self.get_cookies_privacy = self.app.router['CookiesPrivacy:get'].url_for()
+        self.get_contact_us = self.app.router['ContactUs:get'].url_for()
         self.post_index = self.app.router['Index:post'].url_for()
 
         self.action_plan_id = self.case_json['actionPlanId']

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -20,10 +20,24 @@ class TestHandlers(RHTestCase):
     async def test_get_index(self):
         response = await self.client.request("GET", self.get_index)
         self.assertEqual(response.status, 200)
-        contents = await response.content.read()
-        self.assertIn(b'Your 12 character access code is on the letter we sent you', contents)
-        self.assertEqual(contents.count(b'input-text'), 3)
-        self.assertIn(b'type="submit"', contents)
+        contents = str(await response.content.read())
+        self.assertIn('Your 12 character access code is on the letter we sent you', contents)
+        self.assertEqual(contents.count('input-text'), 3)
+        self.assertIn('type="submit"', contents)
+
+    @unittest_run_loop
+    async def test_get_cookies_privacy(self):
+        response = await self.client.request("GET", self.get_cookies_privacy)
+        self.assertEqual(response.status, 200)
+        contents = str(await response.content.read())
+        self.assertIn('Cookies and Privacy', contents)
+
+    @unittest_run_loop
+    async def test_get_contact_us(self):
+        response = await self.client.request("GET", self.get_contact_us)
+        self.assertEqual(response.status, 200)
+        contents = str(await response.content.read())
+        self.assertIn('Contact us', contents)
 
     @skip_build_eq
     @unittest_run_loop


### PR DESCRIPTION
# Motivation and Context
Respondent home footer link needs a contact page containing social business contact details.  This is a duplicate of the eQ social contact page with rh header and footer.

# What has changed
- Created contact page on rh
- Linked footer and 500 error page to new contact page
- Unit tests.

# How to test?
- Check content of contact us is correct
- Check links in footer and error page

# Links
https://trello.com/c/59NWvs2p/316-sus053-create-contact-us-content-and-page
