### PR TITLE
SUS013 Make an eQ inaccessible if past the CE end date

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,4 +8,3 @@ INVALID_CODE_MSG = {'text': 'Please re-enter your access code and try again.', "
 NOT_AUTHORIZED_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "level": "ERROR", "type": "SYSTEM_AUTH_ERROR"}  # NOQA
 
 CODE_USED_MSG = {'text': 'Thank you. We have received a response for your address. No further action is required.\nIf you need further assistance, please phone us for free on 0800 085 7376.', "level": "INFO", "type": "CODE_USED"}    # NOQA
-CLOSED_CE_MSG = {'text': 'This study is now closed. Thank you for your interest in participating.', "level": "INFO", "type": "CLOSED_CE"}  # NOQA

--- a/app/eq.py
+++ b/app/eq.py
@@ -33,7 +33,7 @@ def check_ce_has_ended(datetime_object):
     try:
         if datetime.datetime.now(tz=datetime_object.tzinfo) > datetime_object:
             raise ExerciseClosedError
-    except ValueError:
+    except (AttributeError, ValueError):
         raise InvalidEqPayLoad("Unable to compare date objects")
 
 

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -26,8 +26,8 @@ def create_error_middleware(overrides):
                 logger.debug('Redirecting to index', path=request.path)
                 raise web.HTTPMovedPermanently(index_resource.url_for())
             raise ex
-        except ExerciseClosedError:
-            return await ce_closed(request)
+        except ExerciseClosedError as ex:
+            return await ce_closed(request, ex.collection_exercise_id)
         except InvalidEqPayLoad as ex:
             return await eq_error(request, ex.message)
         except ClientConnectionError as ex:
@@ -42,8 +42,8 @@ def create_error_middleware(overrides):
     return middleware_handler
 
 
-async def ce_closed(request):
-    logger.info("Attempt to access collection exercise that has already ended")
+async def ce_closed(request, collex_id):
+    logger.info("Attempt to access collection exercise that has already ended", collex_id=collex_id)
     return aiohttp_jinja2.render_template("closed.html", request, {})
 
 

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -11,3 +11,7 @@ class InvalidEqPayLoad(Exception):
 
 class InvalidIACError(Exception):
     """Raised when the IAC Service returns a 404"""
+
+
+class ExerciseClosedError(Exception):
+    """Raised when a user attempts to access an already ended CE"""

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -15,3 +15,7 @@ class InvalidIACError(Exception):
 
 class ExerciseClosedError(Exception):
     """Raised when a user attempts to access an already ended CE"""
+
+    def __init__(self, collection_exercise_id):
+        super().__init__()
+        self.collection_exercise_id = collection_exercise_id

--- a/app/templates/closed.html
+++ b/app/templates/closed.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}Closed - My Study{% endblock title %}
+
+{% block content %}
+
+<h1 class="saturn" data-ga="info" data-ga-category="info" data-ga-action="info-message-shown" data-ga-label="collection-exercise-closed">
+    This study is now closed.
+</h1>
+
+<p> Thank you for your interest in participating.</p>
+
+{% endblock content %}

--- a/app/templates/closed.html
+++ b/app/templates/closed.html
@@ -8,6 +8,6 @@
     This study is now closed.
 </h1>
 
-<p> Thank you for your interest in participating.</p>
+<p>Thank you for your interest in participating.</p>
 
 {% endblock content %}

--- a/app/templates/closed.html
+++ b/app/templates/closed.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<h1 class="saturn" data-ga="info" data-ga-category="info" data-ga-action="info-message-shown" data-ga-label="collection-exercise-closed">
+<h1 class="saturn" data-ga="error" data-ga-category="info" data-ga-action="info-message" data-ga-label="info_type = CLOSED_CE">
     This study is now closed.
 </h1>
 

--- a/scripts/setup_data.sh
+++ b/scripts/setup_data.sh
@@ -11,6 +11,7 @@ else
 fi;
 cp tests/test_data/setup.env tmp_rm_tools/social-test-setup/.env
 cp tests/test_data/sample/social-survey-sample.csv tmp_rm_tools/social-test-setup/data/
+cp tests/test_data/collection_exercise/test-1-events.csv tmp_rm_tools/social-test-setup/data/
 pushd tmp_rm_tools/social-test-setup
 pipenv install
 make setup-and-execute

--- a/tests/test_data/collection_exercise/collection_exercise_events_closed.json
+++ b/tests/test_data/collection_exercise/collection_exercise_events_closed.json
@@ -1,0 +1,20 @@
+[
+    {
+      "id": "39632788-50ab-420a-9408-2979133d1fdb",
+      "collectionExerciseId": "6553d121-df61-4b3a-8f43-e0726666b8cc",
+      "tag": "return_by",
+      "timestamp": "2018-05-08T00:00:00.000Z"
+    },
+    {
+    "id": "c7ea9f4a-4f6c-4d15-8996-8a08463291ee",
+    "collectionExerciseId": "6553d121-df61-4b3a-8f43-e0726666b8cc",
+    "tag": "ref_period_start",
+    "timestamp": "2018-04-10T00:00:00.000Z"
+    },
+    {
+    "id": "db4bf724-cec8-4114-866d-06443efbb1cb",
+    "collectionExerciseId": "6553d121-df61-4b3a-8f43-e0726666b8cc",
+    "tag": "ref_period_end",
+    "timestamp": "2000-05-31T00:00:00.000Z"
+    }
+]

--- a/tests/test_data/collection_exercise/test-1-events.csv
+++ b/tests/test_data/collection_exercise/test-1-events.csv
@@ -1,0 +1,2 @@
+survey_code,survey_period,mps,go_live,return_by,exercise_end,ref_period_start,ref_period_end
+999,1,230718,240718,040818,310720,240718,040822

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -297,3 +297,8 @@ class RHTestCase(AioHTTPTestCase):
         self.form_data = {
             'iac1': self.iac1, 'iac2': self.iac2, 'iac3': self.iac3, 'action[save_continue]': '',
         }
+
+        class DummyConstructor:
+            _collex_id = self.collection_exercise_id
+            _collex_events = self.collection_exercise_events_json
+        self.dummy_eq = DummyConstructor()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -201,6 +201,8 @@ class RHTestCase(AioHTTPTestCase):
             self.collection_exercise_json = json.load(fp)
         with open('tests/test_data/collection_exercise/collection_exercise_events.json') as fp:
             self.collection_exercise_events_json = json.load(fp)
+        with open('tests/test_data/collection_exercise/collection_exercise_events_closed.json') as fp:
+            self.closed_ce_events_json = json.load(fp)
         with open('tests/test_data/collection_instrument/collection_instrument_eq.json') as fp:
             self.collection_instrument_json = json.load(fp)
         with open('tests/test_data/sample/sample_attributes.json') as fp:

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -363,6 +363,17 @@ class TestEq(RHTestCase):
         # Then the date is formatted correctly
         self.assertEqual(result, '2007-01-25')
 
+    def test_invalid_iso8601_date_format(self):
+        # Given a valid date
+        date = 'invalid_date'
+
+        # When parse_date is called
+        with self.assertRaises(InvalidEqPayLoad) as e:
+            parse_date(date)
+
+        # Then the date is formatted correctly
+        self.assertEqual(e.exception.message, 'Unable to parse invalid_date')
+
     def test_incorrect_date_format(self):
         # Given an invalid date
         date = 'invalid_date'
@@ -392,6 +403,17 @@ class TestEq(RHTestCase):
         self.assertIsNone(check_ce_has_ended(datetime_obj))
 
         # Then an ExerciseEndError is not raised
+
+    def test_check_ce_has_ended_error(self):
+        # Given an invalid date
+        datetime_obj = 'invalid_date'
+
+        # When check_ce_has_ended is called
+        with self.assertRaises(InvalidEqPayLoad) as e:
+            check_ce_has_ended(datetime_obj)
+
+        # Then an InvalidEqPayload is raised
+        self.assertEqual(e.exception.message, 'Unable to compare date objects')
 
     def test_build_response_id(self):
         response_id = build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -4,8 +4,8 @@ from unittest import mock
 from aiohttp.test_utils import unittest_run_loop
 from aioresponses import aioresponses
 
-from app.eq import format_date, find_event_date_by_tag, build_response_id
-from app.exceptions import InvalidEqPayLoad
+from app.eq import check_ce_has_ended, format_date, parse_date, find_event_date_by_tag, build_response_id
+from app.exceptions import ExerciseClosedError, InvalidEqPayLoad
 
 from . import RHTestCase
 
@@ -358,7 +358,7 @@ class TestEq(RHTestCase):
         date = '2007-01-25T12:00:00Z'
 
         # When format_date is called
-        result = format_date(date)
+        result = format_date(parse_date(date))
 
         # Then the date is formatted correctly
         self.assertEqual(result, '2007-01-25')
@@ -373,6 +373,25 @@ class TestEq(RHTestCase):
 
         # Then an InvalidEqPayLoad is raised
         self.assertEqual(e.exception.message, 'Unable to format invalid_date')
+
+    def test_check_ce_has_ended(self):
+        # Given a valid date
+        datetime_obj = parse_date('2007-01-25T12:00:00Z')
+
+        # When check_ce_has_ended is called
+        with self.assertRaises(ExerciseClosedError):
+            check_ce_has_ended(datetime_obj)
+
+        # Then an ExerciseEndError is raised
+
+    def test_check_ce_has_not_ended(self):
+        # Given a valid date
+        datetime_obj = parse_date('2027-01-25T12:00:00Z')
+
+        # When check_ce_has_ended is called
+        self.assertIsNone(check_ce_has_ended(datetime_obj))
+
+        # Then an ExerciseEndError is not raised
 
     def test_build_response_id(self):
         response_id = build_response_id(self.case_id, self.collection_exercise_id, self.iac_code)

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -4,7 +4,7 @@ from unittest import mock
 from aiohttp.test_utils import unittest_run_loop
 from aioresponses import aioresponses
 
-from app.eq import check_ce_has_ended, format_date, parse_date, find_event_date_by_tag, build_response_id
+from app.eq import EqPayloadConstructor, build_response_id, format_date, parse_date
 from app.exceptions import ExerciseClosedError, InvalidEqPayLoad
 
 from . import RHTestCase
@@ -13,77 +13,61 @@ from . import RHTestCase
 class TestEq(RHTestCase):
 
     def test_create_eq_constructor(self):
-        from app import eq
-
-        self.assertIsInstance(eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code), eq.EqPayloadConstructor)
+        self.assertIsInstance(EqPayloadConstructor(self.case_json, self.app, self.iac_code), EqPayloadConstructor)
 
     def test_create_eq_constructor_missing_iac(self):
-        from app import eq
-
         iac_code = ''
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(self.case_json, self.app, iac_code)
+            EqPayloadConstructor(self.case_json, self.app, iac_code)
         self.assertIn('IAC is empty', ex.exception.message)
 
     def test_create_eq_constructor_missing_case_id(self):
-        from app import eq
-
         case_json = self.case_json.copy()
         del case_json['id']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn('No case id in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_case_ref(self):
-        from app import eq
-
         case_json = self.case_json.copy()
         del case_json['caseRef']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn('No case ref in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_sample_unit_ref(self):
-        from app import eq
-
         case_json = self.case_json.copy()
         del case_json['caseGroup']['sampleUnitRef']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn(f'Could not retrieve sample unit ref for case {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_ci_id(self):
-        from app import eq
-
         case_json = self.case_json.copy()
         del case_json['collectionInstrumentId']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn(f'No collectionInstrumentId value for case id {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_ce_id(self):
-        from app import eq
-
         case_json = self.case_json.copy()
         del case_json["caseGroup"]["collectionExerciseId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn(f'No collection id for case id {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_sample_unit_id(self):
-        from app import eq
-
         case_json = self.case_json.copy()
         del case_json["sampleUnitId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            eq.EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.app, self.iac_code)
         self.assertIn(f'No sample unit id for case {self.case_id}', ex.exception.message)
 
     @unittest_run_loop
@@ -94,8 +78,6 @@ class TestEq(RHTestCase):
             mocked_time.return_value = self.eq_payload['iat']
             mocked_uuid4.return_value = self.jti
 
-            from app import eq  # NB: local import to avoid overwriting the patched version for some tests
-
             with aioresponses() as mocked:
                 mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
                 mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
@@ -104,7 +86,7 @@ class TestEq(RHTestCase):
                 mocked.get(self.survey_url, payload=self.survey_json)
 
                 with self.assertLogs('app.eq', 'INFO') as cm:
-                    payload = await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                    payload = await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
                 self.assertLogLine(cm, '', payload=payload)
 
         mocked_uuid4.assert_called()
@@ -130,13 +112,11 @@ class TestEq(RHTestCase):
         ci_json = self.collection_instrument_json.copy()
         del ci_json['type']
 
-        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
-
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"No Collection Instrument type for {self.collection_instrument_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -144,13 +124,11 @@ class TestEq(RHTestCase):
         ci_json = self.collection_instrument_json.copy()
         del ci_json['classifiers']
 
-        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
-
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve classifiers for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -158,13 +136,11 @@ class TestEq(RHTestCase):
         ci_json = self.collection_instrument_json.copy()
         del ci_json['classifiers']['eq_id']
 
-        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
-
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve eq_id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -172,13 +148,11 @@ class TestEq(RHTestCase):
         ci_json = self.collection_instrument_json.copy()
         del ci_json['classifiers']['form_type']
 
-        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
-
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve form_type for eq_id {self.eq_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -186,14 +160,12 @@ class TestEq(RHTestCase):
         ce_json = self.collection_exercise_json.copy()
         del ce_json['exerciseRef']
 
-        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
-
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve period id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -201,22 +173,18 @@ class TestEq(RHTestCase):
         ce_json = self.collection_exercise_json.copy()
         del ce_json['id']
 
-        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
-
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve ce id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_country_code(self):
         sample_json = self.sample_attributes_json.copy()
         del sample_json['attributes']['COUNTRY']
-
-        from app import eq  # NB: local import to avoid overwriting the patched version for some tests
 
         with aioresponses() as mocked:
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
@@ -225,7 +193,7 @@ class TestEq(RHTestCase):
             mocked.get(self.sample_attributes_url, payload=sample_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve country_code for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -246,38 +214,29 @@ class TestEq(RHTestCase):
             self.assertIn(f'Could not retrieve attributes for case {self.case_id}', ex.exception.message)
 
     def test_find_event_date_by_tag(self):
-        find_mandatory_date = functools.partial(find_event_date_by_tag,
-                                                collex_events=self.collection_exercise_events_json,
-                                                collex_id=self.collection_exercise_id,
-                                                mandatory=True)
+        find_mandatory_date = functools.partial(EqPayloadConstructor._find_event_date_by_tag, mandatory=True)
+
         for tag, expected in [
             ("ref_period_start", self.start_date),
             ("ref_period_end", self.end_date),
             ("return_by", self.return_by)
         ]:
-            self.assertEqual(find_mandatory_date(tag), expected)
+            self.assertEqual(find_mandatory_date(self.dummy_eq, tag), expected)
 
     def test_find_event_date_by_tag_missing(self):
-        result = find_event_date_by_tag("ref_period_start",
-                                        [],
-                                        self.collection_exercise_id,
-                                        False)
+        self.dummy_eq._collex_events = []
+        result = EqPayloadConstructor._find_event_date_by_tag(self.dummy_eq, "ref_period_start", False)
         self.assertIsNone(result)
 
     def test_find_event_date_by_tag_missing_mandatory(self):
+        self.dummy_eq._collex_events = []
         with self.assertRaises(InvalidEqPayLoad) as e:
-            find_event_date_by_tag("ref_period_start",
-                                   [],
-                                   self.collection_exercise_id,
-                                   True)
+            EqPayloadConstructor._find_event_date_by_tag(self.dummy_eq, "ref_period_start", True)
         self.assertIn("ref_period_start", e.exception.message)
 
     def test_find_event_date_by_tag_unexpected_mandatory(self):
         with self.assertRaises(InvalidEqPayLoad) as e:
-            find_event_date_by_tag("unexpected",
-                                   self.collection_exercise_events_json,
-                                   self.collection_exercise_id,
-                                   True)
+            EqPayloadConstructor._find_event_date_by_tag(self.dummy_eq, "unexpected", True)
         self.assertIn("unexpected", e.exception.message)
 
     def test_caps_to_snake(self):
@@ -391,7 +350,7 @@ class TestEq(RHTestCase):
 
         # When check_ce_has_ended is called
         with self.assertRaises(ExerciseClosedError):
-            check_ce_has_ended(datetime_obj)
+            EqPayloadConstructor._check_ce_has_ended(self.dummy_eq, datetime_obj)
 
         # Then an ExerciseEndError is raised
 
@@ -400,7 +359,7 @@ class TestEq(RHTestCase):
         datetime_obj = parse_date('2027-01-25T12:00:00Z')
 
         # When check_ce_has_ended is called
-        self.assertIsNone(check_ce_has_ended(datetime_obj))
+        self.assertIsNone(EqPayloadConstructor._check_ce_has_ended(self.dummy_eq, datetime_obj))
 
         # Then an ExerciseEndError is not raised
 
@@ -410,7 +369,7 @@ class TestEq(RHTestCase):
 
         # When check_ce_has_ended is called
         with self.assertRaises(InvalidEqPayLoad) as e:
-            check_ce_has_ended(datetime_obj)
+            EqPayloadConstructor._check_ce_has_ended(self.dummy_eq, datetime_obj)
 
         # Then an InvalidEqPayload is raised
         self.assertEqual(e.exception.message, 'Unable to compare date objects')

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -179,7 +179,9 @@ class TestHandlers(RHTestCase):
             with self.assertLogs('respondent-home', 'INFO') as logs_home:
                 response = await self.client.request("POST", self.post_index, allow_redirects=False,
                                                      data=self.form_data)
-            self.assertLogLine(logs_home, 'Attempt to access collection exercise that has already ended')
+            self.assertLogLine(logs_home,
+                               'Attempt to access collection exercise that has already ended',
+                               collex_id=self.collection_exercise_id)
 
         self.assertEqual(response.status, 200)
         self.assertIn('This study is now closed', str(await response.content.read()))

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -162,6 +162,28 @@ class TestHandlers(RHTestCase):
                 continue  # skip uuid / time generated values
             self.assertEqual(self.eq_payload[key], token[key], key)  # outputs failed key as msg
 
+    @unittest_run_loop
+    async def test_post_index_build_closed_ce(self):
+        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
+            # mocks for initial data setup in post
+            mocked.get(self.iac_url, payload=self.iac_json)
+            mocked.get(self.case_url, payload=self.case_json)
+            mocked.post(self.case_events_url)
+            # mocks for the payload builder
+            mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
+            mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
+            mocked.get(self.collection_exercise_events_url, payload=self.closed_ce_events_json)
+            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
+            mocked.get(self.survey_url, payload=self.survey_json)
+
+            with self.assertLogs('respondent-home', 'INFO') as logs_home:
+                response = await self.client.request("POST", self.post_index, allow_redirects=False,
+                                                     data=self.form_data)
+            self.assertLogLine(logs_home, 'Attempt to access collection exercise that has already ended')
+
+        self.assertEqual(response.status, 200)
+        self.assertIn('This study is now closed', str(await response.content.read()))
+
     @build_eq_raises
     @unittest_run_loop
     async def test_post_index_build_raises_InvalidEqPayLoad(self):


### PR DESCRIPTION
# Motivation and Context
As a: Social Survey Team Member
I need: A given Collection Exercise to close and become unavailable when the "End Date" is reached
So that: Respondents can no longer access the EQ

[SUS013](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/756908125/SUS013+Close+Collection+Exercise)

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added an error handler which renders a page when accessing a collection exercise with an end date that is already in the past
- Separated the parsing and formatting logic of datestrings.
- Refactored payload builder class to include event-related methods.
- Added a new data file for loading collection exercise events with rm-tools.
- Added and updated unit tests.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the unit tests and flake8 (`make test` for both)
- Amend a collection exercise event with the tag "ref_period_end" to something in the past and try to access using a valid access code. 
