### PR TITLE
SUS054 / IT003: User enters a code for a completed study

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,5 +6,3 @@ BAD_CODE_TYPE_MSG = {'text': 'Please re-enter your access code and try again.', 
 BAD_RESPONSE_MSG = {'text': 'There was an error, please enter your access code and try again.', "clickable": True, "level": "ERROR", "type": "SYSTEM_RESPONSE_ERROR"}  # NOQA
 INVALID_CODE_MSG = {'text': 'Please re-enter your access code and try again.', "clickable": True, "level": "ERROR", "type": "INVALID_CODE"}  # NOQA
 NOT_AUTHORIZED_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "level": "ERROR", "type": "SYSTEM_AUTH_ERROR"}  # NOQA
-
-CODE_USED_MSG = {'text': 'Thank you. We have received a response for your address. No further action is required.\nIf you need further assistance, please phone us for free on 0800 085 7376.', "level": "INFO", "type": "CODE_USED"}    # NOQA

--- a/app/case.py
+++ b/app/case.py
@@ -10,7 +10,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 async def get_case(case_id: str, app: Application):
     url = f"{app['CASE_URL']}/cases/{case_id}"
-    logger.info(f"Making GET request to {url}")
+    logger.debug(f"Making GET request to {url}")
     async with app.http_session_pool.get(url, auth=app["CASE_AUTH"]) as response:
         try:
             response.raise_for_status()
@@ -24,7 +24,7 @@ async def get_case(case_id: str, app: Application):
 
 async def post_case_event(case_id: str, category: str, description: str, app: Application):
     url = f"{app['CASE_URL']}/cases/{case_id}/events"
-    logger.info(f"Making POST request to {url}")
+    logger.debug(f"Making POST request to {url}")
     async with app.http_session_pool.post(
         url,
         auth=app["CASE_AUTH"],

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -6,7 +6,7 @@ from aiohttp.client_exceptions import (
     ClientResponseError, ClientConnectorError, ClientConnectionError, ContentTypeError)
 from structlog import wrap_logger
 
-from .exceptions import ExerciseClosedError, InvalidEqPayLoad
+from .exceptions import ExerciseClosedError, InactiveCaseError, InvalidEqPayLoad
 
 
 logger = wrap_logger(logging.getLogger("respondent-home"))
@@ -26,6 +26,8 @@ def create_error_middleware(overrides):
                 logger.debug('Redirecting to index', path=request.path)
                 raise web.HTTPMovedPermanently(index_resource.url_for())
             raise ex
+        except InactiveCaseError:
+            return await inactive_case(request)
         except ExerciseClosedError as ex:
             return await ce_closed(request, ex.collection_exercise_id)
         except InvalidEqPayLoad as ex:
@@ -40,6 +42,11 @@ def create_error_middleware(overrides):
             return await response_error(request)
 
     return middleware_handler
+
+
+async def inactive_case(request):
+    logger.info("Attempt to use an inactive access code")
+    return aiohttp_jinja2.render_template("completed.html", request, {})
 
 
 async def ce_closed(request, collex_id):

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -7,7 +7,7 @@ from sdc.crypto.encrypter import encrypt
 from structlog import wrap_logger
 
 from . import (
-    BAD_CODE_MSG, BAD_CODE_TYPE_MSG, BAD_RESPONSE_MSG, CODE_USED_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG, VERSION)
+    BAD_CODE_MSG, BAD_CODE_TYPE_MSG, BAD_RESPONSE_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG, VERSION)
 from .case import get_case, post_case_event
 from .eq import EqPayloadConstructor
 from .exceptions import InactiveCaseError, InvalidIACError

--- a/app/templates/completed.html
+++ b/app/templates/completed.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Study complete - My Study{% endblock title %}
+
+{% block content %}
+
+<h1 class="saturn" data-ga="error" data-ga-category="info" data-ga-action="info-message" data-ga-label="info_type = CODE_USED">
+    Study complete
+</h1>
+
+<p>Your access code has been used to complete this study.</p>
+
+<p>Thank you for your help.</p>
+
+{% endblock content %}

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -356,7 +356,7 @@ class TestHandlers(RHTestCase):
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=case_json)
 
-            with self.assertLogs('respondent-home', 'ERROR') as cm:
+            with self.assertLogs('respondent-home', 'WARN') as cm:
                 response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertLogLine(cm, 'Attempt to use unexpected sample unit type', sample_unit_type='B')
 
@@ -391,7 +391,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Attempt to use an inactive access code")
 
         self.assertEqual(response.status, 200)
-        self.assertMessagePanel(CODE_USED_MSG, str(await response.content.read()))
+        self.assertIn('Study complete', str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_inactive(self):
@@ -406,7 +406,7 @@ class TestHandlers(RHTestCase):
             self.assertLogLine(cm, "Attempt to use an inactive access code")
 
         self.assertEqual(response.status, 200)
-        self.assertMessagePanel(CODE_USED_MSG, str(await response.content.read()))
+        self.assertIn('Study complete', str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_iac_service_connection_error(self):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -7,7 +7,7 @@ from aiohttp.test_utils import unittest_run_loop
 from aioresponses import aioresponses
 
 from app import (
-    BAD_CODE_MSG, BAD_CODE_TYPE_MSG, BAD_RESPONSE_MSG, CODE_USED_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG)
+    BAD_CODE_MSG, BAD_CODE_TYPE_MSG, BAD_RESPONSE_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG)
 from app.exceptions import InactiveCaseError
 from app.handlers import Index
 


### PR DESCRIPTION
# Motivation and Context
Send user to page when they enter an access code that has already been used to submit a completed study.  
Note: This page should take precedence over the study closed message if the user has completed the survey. 

# How to test?
- Check page displays if user submits an IAC in RH that has already been used to complete a study.
- Check above scenario after a collection exercise has closed.

# Links
https://trello.com/c/BJrPLZoZ/306-sus054-it003-user-enters-a-code-for-a-completed-study

# Screenshots (if appropriate):
<img width="1030" alt="screen shot 2018-10-25 at 07 57 09" src="https://user-images.githubusercontent.com/43346934/47481466-96ccd600-d82b-11e8-87e5-cdfdac1c39aa.png">