### PR TITLE
Fix / SUS013: Use the exercise_end event to check whether a CE has closed

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -263,8 +263,9 @@ class EqPayloadConstructor(object):
 
     def _get_collex_event_dates(self):
         return {
+            "exercise_end": self._find_event_date_by_tag("exercise_end", True, cmp_func=self._check_ce_has_ended),
             "ref_p_start_date": self._find_event_date_by_tag("ref_period_start", False),
-            "ref_p_end_date": self._find_event_date_by_tag("ref_period_end", False, cmp_func=self._check_ce_has_ended),
+            "ref_p_end_date": self._find_event_date_by_tag("ref_period_end", False),
             "return_by": self._find_event_date_by_tag("return_by", False),
         }
 

--- a/tests/test_data/collection_exercise/collection_exercise_events.json
+++ b/tests/test_data/collection_exercise/collection_exercise_events.json
@@ -16,5 +16,11 @@
     "collectionExerciseId": "6553d121-df61-4b3a-8f43-e0726666b8cc",
     "tag": "ref_period_end",
     "timestamp": "2020-05-31T00:00:00.000Z"
+    },
+    {
+    "id": "f64f2382-2c79-41af-abec-9cb729f12625",
+    "collectionExerciseId": "6553d121-df61-4b3a-8f43-e0726666b8cc",
+    "tag": "exercise_end",
+    "timestamp": "2020-05-31T00:00:00.000Z"
     }
 ]

--- a/tests/test_data/collection_exercise/collection_exercise_events_closed.json
+++ b/tests/test_data/collection_exercise/collection_exercise_events_closed.json
@@ -16,5 +16,11 @@
     "collectionExerciseId": "6553d121-df61-4b3a-8f43-e0726666b8cc",
     "tag": "ref_period_end",
     "timestamp": "2000-05-31T00:00:00.000Z"
+    },
+    {
+    "id": "f64f2382-2c79-41af-abec-9cb729f12625",
+    "collectionExerciseId": "6553d121-df61-4b3a-8f43-e0726666b8cc",
+    "tag": "exercise_end",
+    "timestamp": "2007-05-31T00:00:00.000Z"
     }
 ]

--- a/tests/test_data/collection_exercise/test-1-events.csv
+++ b/tests/test_data/collection_exercise/test-1-events.csv
@@ -1,2 +1,2 @@
 survey_code,survey_period,mps,go_live,return_by,exercise_end,ref_period_start,ref_period_end
-999,1,230718,240718,040818,310720,240718,040822
+999,1,231118,240718,040818,310720,240718,040822

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -253,6 +253,7 @@ class RHTestCase(AioHTTPTestCase):
             "return_by": self.return_by,
             "ref_p_end_date": self.end_date,
             "ref_p_start_date": self.start_date,
+            "exercise_end": self.end_date,
             "display_address": f"{self.sample_attributes_json['attributes']['ADDRESS_LINE1']}, {self.sample_attributes_json['attributes']['TOWN_NAME']}",
             "address_line1": self.sample_attributes_json['attributes']['ADDRESS_LINE1'],
             "address_line2": self.sample_attributes_json['attributes']['ADDRESS_LINE2'],


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, RH was (incorrectly) using the "period end" to check whether a collection exercise had ended. This fix adds the use of the "exercise_end" tag, which will also (harmlessly) be passed to the payload as the same key.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added the fetching and parsing of event with the tag "exercise_end" during payload creation
- Updated unit tests and test data
- Made sure "exercise_end" was present and after "mps" in the integration test data
