### PR TITLE
Add response logging to flush script

### DIFF
--- a/scripts/flush.py
+++ b/scripts/flush.py
@@ -117,8 +117,8 @@ def flush_cases(case_id):
 
         # Call flusher
         flush_url = eq_url + "/flush?token=" + token
-        response = requests.post(flush_url)
-        print(case_id + " Response: " + response.json())
+        flush_response = requests.post(flush_url)
+        print(case_id + " Response: " + str(flush_response.status_code))
 
 if __name__ == '__main__':
     collection_ex = sys.argv[1:]

--- a/scripts/flush.py
+++ b/scripts/flush.py
@@ -118,7 +118,7 @@ def flush_cases(case_id):
         # Call flusher
         flush_url = eq_url + "/flush?token=" + token
         flush_response = requests.post(flush_url)
-        print(case_id + " Response: " + str(flush_response.status_code))
+        print(f'Response from flushing {case_id}: {flush_response.status_code}')
 
 if __name__ == '__main__':
     collection_ex = sys.argv[1:]

--- a/scripts/flush.py
+++ b/scripts/flush.py
@@ -117,8 +117,8 @@ def flush_cases(case_id):
 
         # Call flusher
         flush_url = eq_url + "/flush?token=" + token
-        requests.post(flush_url)
-
+        response = requests.post(flush_url)
+        print(case_id + " Response: " + response.json())
 
 if __name__ == '__main__':
     collection_ex = sys.argv[1:]


### PR DESCRIPTION
# Motivation and Context
The flush script did not indicate the response from the EQ flush endpoint, this PR adds it in.

# What has changed
Added printing of the response from the EQ flush endpoint

# How to test?
Like before, have EQ survey runner docker containers running alongside the docker dev containers and start a collection exercise. Partially complete some and then run the flush script:
pipenv run python scripts/flush.py _collection-exercise-id
You should see the response from the EQ flush printed out in the terminal you ran the script from.  

# Links
https://trello.com/c/lNmyBmPH/214-sus014-send-partial-data-downstream-13

# Screenshots (if appropriate):