### PR TITLE
Make redis host and port config variables optional

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -61,10 +61,10 @@ class BaseConfig:
     SURVEY_URL = env("SURVEY_URL")
     SURVEY_AUTH = (env("SURVEY_USERNAME"), env("SURVEY_PASSWORD"))
 
-    REDIS_HOST = env("REDIS_HOST")
-    REDIS_PORT = env("REDIS_PORT")
+    REDIS_SERVICE = env("REDIS_SERVICE")  # required to populate host and port with cf values
+    REDIS_HOST = env("REDIS_HOST", default="")  # populated by cf after setup
+    REDIS_PORT = env("REDIS_PORT", default="")  # populated by cf after setup
     REDIS_MAINTENANCE_KEY = env("REDIS_MAINTENANCE_KEY", default="respondent-home-ui:maintenance")
-    REDIS_SERVICE = env("REDIS_SERVICE")
 
     SECRET_KEY = env("SECRET_KEY")
 


### PR DESCRIPTION
If cloud foundry is detected (using REDIS_SERVICE), REDIS_HOST and REDIS_PORT will be populated after app setup. To avoid ConfigurationError being raised these should be optional (default: empty string) in production.