### PR TITLE
TBL Ignore deprecation warnings from unittests and elevate others to error

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    error
+    ignore::DeprecationWarning


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Quick fix to stop the spammy messages produced from deprecation warnings regarding router argument in app setup.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Pytest config added to ignore DeprecationWarning but elevate any others to Error.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
`make test`

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[#2252](https://github.com/aio-libs/aiohttp/issues/2252)
[#85](https://github.com/ONSdigital/respondent-home-ui/issues/85)