### PR TITLE
revert error on pytest warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 filterwarnings =
-    error
     ignore::DeprecationWarning


### PR DESCRIPTION
# Motivation and Context
Pytest was set to error on warnings in the unit tests, but the smoke tests are also run with the same pytest config causing errors in the smoke tests in the pipeline.

# What has changed
- Do not raise error on warnings in pytest

# Links
#92 