### PR TITLE
Display different pages for completed cases and inactive iac

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,5 +1,9 @@
-class InactiveCaseError(Exception):
-    """Raised when a user enters a used IAC code"""
+class CompletedCaseError(Exception):
+    """Raised when a user enters a IAC code for a completed case"""
+
+
+class InactiveIACError(Exception):
+    """Raised when a user enters an inactive IAC code"""
 
 
 class InvalidEqPayLoad(Exception):

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -59,10 +59,15 @@ class Index:
     @staticmethod
     def validate_iac_active(iac_json, case_json):
         if not iac_json.get("active", False):
-            if case_json.get('caseGroupStatus') == 'COMPLETED':
-                raise CompletedCaseError
-            else:
-                raise InactiveIACError
+            try:
+                if case_json['caseGroup']['caseGroupStatus'] in ['COMPLETE', 'COMPLETEDBYPHONE']:
+                    logger.info('Attempt to use inactive iac for completed case')
+                    raise CompletedCaseError
+            except KeyError:
+                logger.warn("Field case_json['caseGroup']['caseGroupStatus'] not found")
+
+            logger.info('Attempt to use inactive iac for incomplete case')
+            raise InactiveIACError
 
     def check_case_sample_unit_type_valid(self, case_json):
         try:

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -78,7 +78,7 @@ class Index:
             except KeyError:
                 logger.warn("Field case_json['caseGroup']['caseGroupStatus'] not found")
 
-            logger.info('Attempt to use inactive iac for incomplete case, collex id: ' + collex_id)
+            logger.info('Attempt to use inactive iac for incomplete case', collex_id=collex_id)
             raise InactiveIACError
 
     def check_case_sample_unit_type_valid(self, case_json):

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -21,7 +21,8 @@ routes = RouteTableDef()
 @routes.view('/info', use_prefix=False)
 class Info:
 
-    async def get(self, request):
+    @staticmethod
+    async def get(request):
         info = {
             "name": 'respondent-home-ui',
             "version": VERSION,

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -61,8 +61,7 @@ class Index:
         try:
             return case_json['caseGroup']['collectionExerciseId']
         except KeyError:
-            logger.warn("Failed to get case_json['caseGroup']['collectionExerciseId']")
-
+            logger.warn("Failed to get collex_id from case_json['caseGroup']['collectionExerciseId']")
 
     @staticmethod
     def validate_iac_active(iac_json, case_json):

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -57,16 +57,28 @@ class Index:
         return combined
 
     @staticmethod
+    def get_collex_id(case_json):
+        try:
+            collex_id = case_json['caseGroup']['collectionExerciseId']
+        except KeyError:
+            logger.warn("Failed to get case_json['caseGroup']['collectionExerciseId']")
+            collex_id = "[collex_id not found]"
+
+        return collex_id
+
+    @staticmethod
     def validate_iac_active(iac_json, case_json):
         if not iac_json.get("active", False):
+            collex_id = Index.get_collex_id(case_json)
+
             try:
                 if case_json['caseGroup']['caseGroupStatus'] == 'COMPLETE':
-                    logger.info('Attempt to use inactive iac for completed case')
+                    logger.info('Attempt to use inactive iac for completed case, collex id: ' + collex_id)
                     raise CompletedCaseError
             except KeyError:
                 logger.warn("Field case_json['caseGroup']['caseGroupStatus'] not found")
 
-            logger.info('Attempt to use inactive iac for incomplete case')
+            logger.info('Attempt to use inactive iac for incomplete case, collex id: ' + collex_id)
             raise InactiveIACError
 
     def check_case_sample_unit_type_valid(self, case_json):

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -62,7 +62,6 @@ class Index:
             return case_json['caseGroup']['collectionExerciseId']
         except KeyError:
             logger.warn("Failed to get case_json['caseGroup']['collectionExerciseId']")
-            collex_id = "[collex_id not found]"
 
 
     @staticmethod

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -73,7 +73,7 @@ class Index:
 
             try:
                 if case_json['caseGroup']['caseGroupStatus'] == 'COMPLETE':
-                    logger.info('Attempt to use inactive iac for completed case, collex id: ' + collex_id)
+                    logger.info('Attempt to use inactive iac for completed case', collex_id=collex_id)
                     raise CompletedCaseError
             except KeyError:
                 logger.warn("Field case_json['caseGroup']['caseGroupStatus'] not found")

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -64,7 +64,6 @@ class Index:
             logger.warn("Failed to get case_json['caseGroup']['collectionExerciseId']")
             collex_id = "[collex_id not found]"
 
-        return collex_id
 
     @staticmethod
     def validate_iac_active(iac_json, case_json):

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -59,7 +59,7 @@ class Index:
     @staticmethod
     def get_collex_id(case_json):
         try:
-            collex_id = case_json['caseGroup']['collectionExerciseId']
+            return case_json['caseGroup']['collectionExerciseId']
         except KeyError:
             logger.warn("Failed to get case_json['caseGroup']['collectionExerciseId']")
             collex_id = "[collex_id not found]"

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -60,7 +60,7 @@ class Index:
     def validate_iac_active(iac_json, case_json):
         if not iac_json.get("active", False):
             try:
-                if case_json['caseGroup']['caseGroupStatus'] in ['COMPLETE', 'COMPLETEDBYPHONE']:
+                if case_json['caseGroup']['caseGroupStatus'] == 'COMPLETE':
                     logger.info('Attempt to use inactive iac for completed case')
                     raise CompletedCaseError
             except KeyError:

--- a/app/templates/inactive-iac.html
+++ b/app/templates/inactive-iac.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Access Code Inactive{% endblock title %}
+
+{% block content %}
+
+<h1 class="saturn" data-ga="error" data-ga-category="info" data-ga-action="info-message" data-ga-label="info_type = CODE_USED">
+    Access code disabled
+</h1>
+
+<p>The access code you entered has been disabled.</p>
+
+<p>If you need help accessing your study, please <a href="{{ url('ContactUs:get') }}">contact us</a></p>
+
+{% endblock content %}

--- a/app/templates/inactive-iac.html
+++ b/app/templates/inactive-iac.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<h1 class="saturn" data-ga="error" data-ga-category="info" data-ga-action="info-message" data-ga-label="info_type = CODE_USED">
+<h1 class="saturn" data-ga="error" data-ga-category="info" data-ga-action="info-message" data-ga-label="info_type = CODE_INACTIVE">
     Access code disabled
 </h1>
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -416,24 +416,6 @@ class TestHandlers(RHTestCase):
         self.assertIn('Study complete', str(await response.content.read()))
 
     @unittest_run_loop
-    async def test_post_index_case_completed_by_phone(self):
-        iac_json = self.iac_json.copy()
-        iac_json['active'] = False
-        case_json = self.case_json.copy()
-        case_json['caseGroup']['caseGroupStatus'] = 'COMPLETEDBYPHONE'
-
-        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            mocked.get(self.iac_url, payload=iac_json)
-            mocked.get(self.case_url, payload=case_json)
-
-            with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", self.post_index, data=self.form_data)
-            self.assertLogLine(cm, "Attempt to use an inactive iac for a completed case")
-
-        self.assertEqual(response.status, 200)
-        self.assertIn('Study complete', str(await response.content.read()))
-
-    @unittest_run_loop
     async def test_missing_case_group_status(self):
         iac_json = self.iac_json.copy()
         iac_json['active'] = False

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -8,7 +8,7 @@ from aioresponses import aioresponses
 
 from app import (
     BAD_CODE_MSG, BAD_CODE_TYPE_MSG, BAD_RESPONSE_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG)
-from app.exceptions import CompletedCaseError, InactiveIACError
+from app.exceptions import InactiveIACError
 from app.handlers import Index
 
 from . import RHTestCase, build_eq_raises, skip_build_eq, skip_encrypt

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -475,7 +475,7 @@ class TestHandlers(RHTestCase):
                 response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Attempt to use an iac code that is inactive,"
                                    " malformed or iac_details missing active field")
-            self.assertLogLine(cm, collex_id=None)
+            self.assertLogLine(cm, "Failed to get collex_id from case_json['caseGroup']['collectionExerciseId']")
 
         self.assertEqual(response.status, 200)
         response_content = str(await response.content.read())

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -475,7 +475,7 @@ class TestHandlers(RHTestCase):
                 response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Attempt to use an iac code that is inactive,"
                                    " malformed or iac_details missing active field")
-            self.assertLogLine(cm, "[collex_id not found]")
+            self.assertLogLine(cm, collex_id=None)
 
         self.assertEqual(response.status, 200)
         response_content = str(await response.content.read())

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -452,7 +452,7 @@ class TestHandlers(RHTestCase):
                 response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Attempt to use an iac code that is inactive,"
                                    " malformed or iac_details missing active field")
-            self.assertLogLine(cm, "Attempt to use inactive iac for incomplete case, collex id: expected_collex_id")
+            self.assertLogLine(cm, "Attempt to use inactive iac for incomplete case", collex_id='expected_collex_id')
 
         self.assertEqual(response.status, 200)
         response_content = str(await response.content.read())

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -383,7 +383,7 @@ class TestHandlers(RHTestCase):
         iac_json = self.iac_json.copy()
         del iac_json['active']
         case_json = self.case_json.copy()
-        case_json['caseGroupStatus'] = 'OTHERNONRESPONSE'
+        case_json['caseGroup']['caseGroupStatus'] = 'OTHERNONRESPONSE'
 
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
             mocked.get(self.iac_url, payload=iac_json)
@@ -402,7 +402,7 @@ class TestHandlers(RHTestCase):
         iac_json = self.iac_json.copy()
         iac_json['active'] = False
         case_json = self.case_json.copy()
-        case_json['caseGroupStatus'] = 'COMPLETED'
+        case_json['caseGroup']['caseGroupStatus'] = 'COMPLETE'
 
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
             mocked.get(self.iac_url, payload=iac_json)
@@ -416,11 +416,29 @@ class TestHandlers(RHTestCase):
         self.assertIn('Study complete', str(await response.content.read()))
 
     @unittest_run_loop
-    async def test_post_index_iac_inactive(self):
+    async def test_post_index_case_completed_by_phone(self):
         iac_json = self.iac_json.copy()
         iac_json['active'] = False
         case_json = self.case_json.copy()
-        case_json['caseGroupStatus'] = 'OTHERNONRESPONSE'
+        case_json['caseGroup']['caseGroupStatus'] = 'COMPLETEDBYPHONE'
+
+        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
+            mocked.get(self.iac_url, payload=iac_json)
+            mocked.get(self.case_url, payload=case_json)
+
+            with self.assertLogs('respondent-home', 'INFO') as cm:
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
+            self.assertLogLine(cm, "Attempt to use an inactive iac for a completed case")
+
+        self.assertEqual(response.status, 200)
+        self.assertIn('Study complete', str(await response.content.read()))
+
+    @unittest_run_loop
+    async def test_missing_case_group_status(self):
+        iac_json = self.iac_json.copy()
+        iac_json['active'] = False
+        case_json = self.case_json.copy()
+        del case_json['caseGroup']['caseGroupStatus']
 
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
             mocked.get(self.iac_url, payload=iac_json)
@@ -432,7 +450,27 @@ class TestHandlers(RHTestCase):
                                    " malformed or iac_details missing active field")
 
         self.assertEqual(response.status, 200)
+        response_content = str(await response.content.read())
+        self.assertIn('Access code disabled', response_content)
+        self.assertIn('The access code you entered has been disabled', response_content)
 
+    @unittest_run_loop
+    async def test_post_index_iac_inactive(self):
+        iac_json = self.iac_json.copy()
+        iac_json['active'] = False
+        case_json = self.case_json.copy()
+        case_json['caseGroup']['caseGroupStatus'] = 'OTHERNONRESPONSE'
+
+        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
+            mocked.get(self.iac_url, payload=iac_json)
+            mocked.get(self.case_url, payload=case_json)
+
+            with self.assertLogs('respondent-home', 'INFO') as cm:
+                response = await self.client.request("POST", self.post_index, data=self.form_data)
+            self.assertLogLine(cm, "Attempt to use an iac code that is inactive,"
+                                   " malformed or iac_details missing active field")
+
+        self.assertEqual(response.status, 200)
         response_content = str(await response.content.read())
         self.assertIn('Access code disabled', response_content)
         self.assertIn('The access code you entered has been disabled', response_content)


### PR DESCRIPTION
Display different pages for completed cases and inactive iac codes for other reasons

# Motivation and Context
Currently this app displays a 'case completed' page when any inactive iac is used.  This is correct if the case is completed.  However it's possible in social for a refusal 562 for an iac to be set to inactive.  In this case the page should be say that the iac is inactive

# What has changed
<!--- What code changes has been made -->

- New html page inactive-iac.html added.  
- New code to check if an inactive iac is for a completed case or not.
<!--- Has there been any refactoring -->
- Renamed some variables and functions.  Extracted sample unit type check to seperate
<!--- What tests have been written -->
- test_post_index_iac_active_missing, test_post_index_case_complete,
 test_missing_case_group_status, test_post_index_iac_inactive

# How to test?
<!--- Describe in detail how you tested your changes. -->
    Checkout this branch.  
    In ras-rm-docker-dev do **make pull**
    In respondent-home-ui run docker **build . -t sdcplatform/respondent-home-ui**
    In ras-rm-docker-dev run **make up** and wait for system to be fully up.
    
- **Test Locally**
   - In respondent-home-ui run **make install** then run **make test** all tests should pass
   - Get latest copy of acceptance tests and run **make acceptance_tests** all should pass
 
- **Manually Test**
   - Browse go to http://localhost:8003/survey and create a new LMS social Collection exercise to 
      start in the next few minutes.  Use the attached DUMMYSAMPLE.csv (given suffix .txt to upload 
      here, but remove when downloaded
   - Browse to http://localhost:8086/ and enter **np10 8xg**  as the postcode, choose a case and 
      create a new iac for it (record this)
   - Browse to http://localhost:9092/ and use this code, the browser should attempt (and fail) to 
      redirect to an EQ, page not found etc
   - Mock the affect of a normally completed case by using pgAdmin change iac.iac active to false for 
      the new iac you have generated (your new one should be at the bottom).  On the table 
      casesvc.casegroup update the case  (sampleunitref should match, eg DUM100012).  Then reuse 
      the iac code in a refreshed http://localhost:9092/ and it should now display a page stating 'Study 
      Completed'.
   - Now in http://localhost:8086/ choose a new case and create a new iac for it, record this.  Then 
      change the status on this case to 562 with the UI.  Now browse to http://localhost:9092/ and 
      use the iac.  This should now display a page with 'Access code disabled'

<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
#What I did locally
- I used a standard local environment and ran manual test as above.  
- Ran **make test** to test project
- Ran **make acceptance_tests** to test the whole system

[DUMMYSample.csv.txt](https://github.com/ONSdigital/respondent-home-ui/files/2671743/DUMMYSample.csv.txt)

<!--- Are there any automated tests that mean changes don't need to be manually changed -->
No new automated tests as this only touches one service and doesn't break any existing tests.

# Links
https://trello.com/c/KKYcX9A8/331-sus057-manage-error-messages-for-disabled-completed-closed-surveys
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):