### PR TITLE
Convert incoming UTC dates to system local

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -36,7 +36,7 @@ def parse_date(string_date):
     :return: datetime object
     """
     try:
-        return iso8601.parse_date(string_date)
+        return iso8601.parse_date(string_date).astimezone()
     except (ValueError, iso8601.iso8601.ParseError):
         raise InvalidEqPayLoad(f"Unable to parse {string_date}")
 

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -322,6 +322,16 @@ class TestEq(RHTestCase):
         # Then the date is formatted correctly
         self.assertEqual(result, '2007-01-25')
 
+    def test_iso8601_adjusts_to_local_time(self):
+        # Given a valid date in tz -1hr before midnight
+        date = '2007-01-25T23:59:59-0100'
+
+        # When format_date is called
+        result = format_date(parse_date(date))
+
+        # Then the date is localised to the next day
+        self.assertEqual(result, '2007-01-26')
+
     def test_invalid_iso8601_date_format(self):
         # Given a valid date
         date = 'invalid_date'


### PR DESCRIPTION
# Motivation and Context

"When Collection exercise event dates are added through Response-Ops, they are converted to UTC prior to being stored and are converted back to local time to be displayed on the collection exercise page, which is all good.

[This service] retrieves the collection exercise dates to form part of the eq_payload but doesn't convert the dates from UTC. We only send the date part of the date/time string and this has resulted in us passing incorrect dates to eQ." - spotted in ras-frontstage.

# What has changed

- Doing .[asTimeZone](https://docs.python.org/3/library/datetime.html#datetime.datetime.astimezone)() brings the iso8601 parsed date back from UTC to the server local timezone
- Added contrived unit test

# How to test?
`make test`

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
- [Related frontstage PR](https://github.com/ONSdigital/ras-frontstage/pull/422)
