### PR TITLE
Create DNS entries for each service

### DIFF
--- a/_infra/helm/respondent-home-ui/Chart.yaml
+++ b/_infra/helm/respondent-home-ui/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/respondent-home-ui/templates/deployment.yaml
+++ b/_infra/helm/respondent-home-ui/templates/deployment.yaml
@@ -72,25 +72,41 @@ spec:
           - name: ACCOUNT_SERVICE_URL
             value: "$(ACCOUNT_SERVICE_URL)"
           - name: CASE_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://case.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "http://$(CASE_SERVICE_HOST):$(CASE_SERVICE_PORT)"
+            {{- end }}
           - name: CASE_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: CASE_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: COLLECTION_EXERCISE_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://collection-exericse.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "http://$(COLLECTION_EXERCISE_SERVICE_HOST):$(COLLECTION_EXERCISE_SERVICE_PORT)"
+            {{- end }}
           - name: COLLECTION_EXERCISE_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: COLLECTION_EXERCISE_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: COLLECTION_INSTRUMENT_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://collection-instrument.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "http://$(COLLECTION_INSTRUMENT_SERVICE_HOST):$(COLLECTION_INSTRUMENT_SERVICE_PORT)"
+            {{- end }}
           - name: COLLECTION_INSTRUMENT_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: COLLECTION_INSTRUMENT_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: IAC_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://iac.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "http://$(IAC_SERVICE_HOST):$(IAC_SERVICE_PORT)"
+            {{- end }}
           - name: IAC_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: IAC_PASSWORD
@@ -114,13 +130,21 @@ spec:
             value: "$(REDIS_MASTER_SERVICE_PORT)"
             {{- end}}
           - name: SAMPLE_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://sample.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "http://$(SAMPLE_SERVICE_HOST):$(SAMPLE_SERVICE_PORT)"
+            {{- end }}
           - name: SAMPLE_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: SAMPLE_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: SURVEY_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://survey.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "http://$(SURVEY_SERVICE_HOST):$(SURVEY_SERVICE_PORT)"
+            {{- end }}
           - name: SURVEY_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: SURVEY_PASSWORD

--- a/_infra/helm/respondent-home-ui/values.yaml
+++ b/_infra/helm/respondent-home-ui/values.yaml
@@ -21,3 +21,7 @@ service:
 resources:
   requests:
     memory: "128Mi"
+
+dns:
+  enabled: false
+  wellKnownPort: 8080


### PR DESCRIPTION
# Motivation and Context
Adds kube_dns addresses for all connecting services to allow us to have circular references