### PR TITLE
Add structlog processor for Google Cloud Logging

### DIFF
--- a/app/app_logging.py
+++ b/app/app_logging.py
@@ -8,7 +8,7 @@ from structlog.stdlib import add_log_level, filter_by_level
 
 
 def logger_initial_config(
-    service_name=None, log_level=None, logger_format=None, logger_date_format=None
+        service_name=None, log_level=None, logger_format=None, logger_date_format=None
 ):
 
     if not logger_date_format:
@@ -35,8 +35,20 @@ def logger_initial_config(
 
     logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
 
+    def add_severity_level(logger, method_name, event_dict):
+        """
+        Add the log level to the event dict.
+        """
+        if method_name == "warn":
+            # The stdlib has an alias
+            method_name = "warning"
+
+        event_dict["severity"] = method_name
+        return event_dict
+
     configure(
         processors=[
+            add_severity_level,
             add_log_level,
             filter_by_level,
             add_service,


### PR DESCRIPTION
# Motivation and Context
Added "severity level" processor to structlog, so Google Cloud Logging can parse severity
<!--- Why is this change required? What problem does it solve? -->

# What has changed
New structlog processor defined in logger config
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Local: make test

dev: Spin up cluster in Dev, with pod built from image tag "cloud-logging"; generate error; check Stackdriver logs for correct parsing and severity levels
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
https://trello.com/c/wDSxYgCQ
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
